### PR TITLE
Don't skip syncing tasks that have been assigned to someone else in Asana

### DIFF
--- a/lib/asana/service.rb
+++ b/lib/asana/service.rb
@@ -38,12 +38,15 @@ module Asana
     # sync tasks from Asana to the primary service
     def sync_to_primary(primary_service)
       asana_tasks = tasks_to_sync
+      # An available task is a task that is assigned to the Asana user (who provided the personal access token) or
+      # is in a project visible to the Asana user and is unassigned
+      available_tasks = asana_tasks.select { |task| task.assignee == asana_user["gid"] || task.assignee.nil? }
       primary_tasks = primary_service.tasks_to_sync(tags: ["Asana"])
       unless options[:quiet]
-        progressbar = ProgressBar.create(format: "%t: %c/%C |%w>%i| %e ", total: asana_tasks.length,
+        progressbar = ProgressBar.create(format: "%t: %c/%C |%w>%i| %e ", total: available_tasks.length,
                                          title: "#{primary_service.class.name} from Asana Tasks")
       end
-      asana_tasks.each do |asana_task|
+      available_tasks.each do |asana_task|
         output = if (existing_task = primary_tasks.find { |primary_task| friendly_titles_match?(primary_task, asana_task) })
           primary_service.update_task(existing_task, asana_task)
         else
@@ -52,7 +55,7 @@ module Asana
         progressbar.log "#{self.class}##{__method__}: #{output}" if !output.blank? && ((options[:pretend] && options[:verbose] && !options[:quiet]) || options[:debug])
         progressbar.increment unless options[:quiet]
       end
-      puts "Synced #{asana_tasks.length} #{options[:primary]} items from Asana" unless options[:quiet]
+      puts "Synced #{available_tasks.length} #{options[:primary]} items from Asana" unless options[:quiet]
     end
 
     # Asana doesn't use tags or an inbox, so just get all tasks in the requested project
@@ -60,10 +63,7 @@ module Asana
       visible_project_gids = list_projects.map { |project| project["gid"] }
       task_list = visible_project_gids.map { |project_gid| list_project_tasks(project_gid) }.flatten.uniq
       tasks = task_list.map { |task| Task.new(task, options) }
-      # An available task is a task that is assigned to the Asana user (who provided the personal access token) or
-      # is in a project visible to the Asana user and is unassigned
-      available_tasks = tasks.select { |task| task.assignee == asana_user["gid"] || task.assignee.nil? }
-      tasks_with_subtasks = available_tasks.select { |task| task.subtask_count.positive? }
+      tasks_with_subtasks = tasks.select { |task| task.subtask_count.positive? }
       if tasks_with_subtasks.any?
         tasks_with_subtasks.each do |parent_task|
           subtask_hashes = list_task_subtasks(parent_task.id)
@@ -73,11 +73,11 @@ module Asana
             # Remove the subtask from the main task list
             # so we don't double sync them
             # (the Asana API doesn't have a filter for subtasks)
-            available_tasks.delete_if { |task| task.id == subtask.id }
+            tasks.delete_if { |task| task.id == subtask.id }
           end
         end
       end
-      available_tasks
+      tasks
     end
     memo_wise :tasks_to_sync
 
@@ -273,20 +273,6 @@ module Asana
       end
     end
     memo_wise :memberships_for_task
-
-    def assigned_workspace_tasks(workspace_gid)
-      query = {
-        query: {
-          assignee: asana_user["gid"],
-          workspace: workspace_gid,
-          opt_fields: Task.requested_fields.join(",")
-        }
-      }
-      response = HTTParty.get("#{base_url}/tasks", authenticated_options.merge(query))
-      raise "Error loading Asana tasks - check personal access token" unless response.success?
-
-      JSON.parse(response.body)["data"]
-    end
 
     def workspace_gids
       workspaces = asana_user["workspaces"]

--- a/spec/lib/omnifocus/service_spec.rb
+++ b/spec/lib/omnifocus/service_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Omnifocus::Service" do
       let(:folder) { "TaskBridge" }
 
       it "returns all tasks in a folder" do
-        expect(subject.count).to eq(4)
+        expect(subject.count).to eq(3)
       end
     end
 


### PR DESCRIPTION
This will continue to update tasks that have been assigned to someone else. However it won't create new tasks that are assigned to someone else. 

Fixes https://github.com/viamin/task_bridge/issues/71