### PR TITLE
require ruby 3.1 in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+ruby '~> 3.1'
+
 source "https://rubygems.org"
 
 # https://github.com/rails/rails/tree/main/activesupport


### PR DESCRIPTION
Why?
Code uses restructured hashes, which are supported only starting with Ruby 3.1