### PR TITLE
Bugfix: Can't split empty array

### DIFF
--- a/lib/task_bridge.rb
+++ b/lib/task_bridge.rb
@@ -32,7 +32,7 @@ class TaskBridge
       conflicts :personal_tags, :work_tags
       opt :services, "Services to sync tasks to", default: ENV.fetch("SYNC_SERVICES", "GoogleTasks,Github").split(",")
       opt :list, "Task list name to sync to", default: ENV.fetch("GOOGLE_TASKS_LIST", "My Tasks")
-      opt :repositories, "Github repositories to sync from", default: ENV.fetch("GITHUB_REPOSITORIES", []).split(",")
+      opt :repositories, "Github repositories to sync from", default: ENV.fetch("GITHUB_REPOSITORIES", "").split(",")
       opt :max_age, "Skip syncing asks that have not been modified within this time (0 to disable)", default: ENV.fetch("SYNC_MAX_AGE", 0).to_i
       opt :delete,
           "Delete completed tasks on service",

--- a/lib/task_bridge.rb
+++ b/lib/task_bridge.rb
@@ -32,7 +32,7 @@ class TaskBridge
       conflicts :personal_tags, :work_tags
       opt :services, "Services to sync tasks to", default: ENV.fetch("SYNC_SERVICES", "GoogleTasks,Github").split(",")
       opt :list, "Task list name to sync to", default: ENV.fetch("GOOGLE_TASKS_LIST", "My Tasks")
-      opt :repositories, "Github repositories to sync from", default: ENV.fetch("GITHUB_REPOSITORIES", "").split(",")
+      opt :repositories, "Github repositories to sync from", type: :strings, default: ENV.fetch("GITHUB_REPOSITORIES", "").split(",")
       opt :max_age, "Skip syncing asks that have not been modified within this time (0 to disable)", default: ENV.fetch("SYNC_MAX_AGE", 0).to_i
       opt :delete,
           "Delete completed tasks on service",


### PR DESCRIPTION
fixes Issue when ENV['GITHUB_REPOSITORIES'] is nil. Cannot split array. Fallback should probably be empty string rather than array.

```
/Users/johnrandall/code/vendor/task_bridge/lib/task_bridge.rb:35:in `block in initialize': undefined method `split' for []:Array (NoMethodError)

      opt :repositories, "Github repositories to sync from", default: ENV.fetch("GITHUB_REPOSITORIES", []).split(",")
                                                                                                          ^^^^^^
	from /Users/johnrandall/.rvm/gems/ruby-3.2.1/gems/optimist-3.0.1/lib/optimist.rb:103:in `call'
	from /Users/johnrandall/.rvm/gems/ruby-3.2.1/gems/optimist-3.0.1/lib/optimist.rb:103:in `initialize'
	from /Users/johnrandall/.rvm/gems/ruby-3.2.1/gems/optimist-3.0.1/lib/optimist.rb:921:in `new'
	from /Users/johnrandall/.rvm/gems/ruby-3.2.1/gems/optimist-3.0.1/lib/optimist.rb:921:in `options'
	from /Users/johnrandall/code/vendor/task_bridge/lib/task_bridge.rb:20:in `initialize'
	from bin/task_bridge:6:in `new'
	from bin/task_bridge:6:in `<main>'
```