### PR TITLE
Pin ruby to exact version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ruby '~> 3.1'
+ruby '3.2.1'
 
 source "https://rubygems.org"
 


### PR DESCRIPTION
RVM can't read a semantic version out of a Gemfile- it requires pinning to an exact ruby version. 

This MR. Pins to the most recent ruby, `3.2.1`. Other options > Ruby 3.1 are `3.1.3`, `3.2.0`, `3.2.1`.