### PR TITLE
Update service.rb

### DIFF
--- a/lib/google_tasks/service.rb
+++ b/lib/google_tasks/service.rb
@@ -134,7 +134,7 @@ module GoogleTasks
     # In case a reclaim title is present, match the title
     def friendly_titles_match?(google_task, task)
       matcher = /\A(?<title>.+)\s*(?<addon>.*)\Z/i
-      google_title = matcher.match(google_task.title).named_captures.fetch("title", nil)&.downcase&.strip
+      google_title = matcher.match(google_task.title)&.named_captures&.fetch("title", nil)&.downcase&.strip
       google_title == task.title&.downcase&.strip
     end
   end


### PR DESCRIPTION
Fixes nil handling error when Google Task title is empty.


```
/Users/johnrandall/.rvm/gems/ruby-3.2.1/gems/rb-scpt-1.0.3/lib/_aem/aemreference.rb:34: warning: undefining the allocator of T_DATA class AE::AEDesc
Starting sync at 2023-02-24 11:43AM
/Users/johnrandall/code/vendor/task_bridge/lib/google_tasks/service.rb:137:in `friendly_titles_match?': undefined method `named_captures' for nil:NilClass (NoMethodError)                          |  ETA: ??:??:??

      google_title = matcher.match(google_task.title).named_captures.fetch("title", nil)&.downcase&.strip
                                                     ^^^^^^^^^^^^^^^
	from /Users/johnrandall/code/vendor/task_bridge/lib/google_tasks/service.rb:47:in `block (2 levels) in sync_from_primary'
	from /Users/johnrandall/code/vendor/task_bridge/lib/google_tasks/service.rb:47:in `each'
	from /Users/johnrandall/code/vendor/task_bridge/lib/google_tasks/service.rb:47:in `find'
	from /Users/johnrandall/code/vendor/task_bridge/lib/google_tasks/service.rb:47:in `block in sync_from_primary'
	from /Users/johnrandall/code/vendor/task_bridge/lib/google_tasks/service.rb:44:in `each'
	from /Users/johnrandall/code/vendor/task_bridge/lib/google_tasks/service.rb:44:in `sync_from_primary'
	from /Users/johnrandall/code/vendor/task_bridge/lib/task_bridge.rb:89:in `block in call'
	from /Users/johnrandall/code/vendor/task_bridge/lib/task_bridge.rb:73:in `each'
	from /Users/johnrandall/code/vendor/task_bridge/lib/task_bridge.rb:73:in `call'
	from bin/task_bridge:6:in `<main>'
```

<img width="298" alt="Screen Shot 2023-02-24 at 11 47 23" src="https://user-images.githubusercontent.com/5943437/221237962-d3d662fb-38b4-44a7-8f79-acb0a4b7e88d.png">
