### PR TITLE
Fix Google Task Sync name matching

### DIFF
--- a/lib/google_tasks/service.rb
+++ b/lib/google_tasks/service.rb
@@ -133,7 +133,7 @@ module GoogleTasks
 
     # In case a reclaim title is present, match the title
     def friendly_titles_match?(google_task, task)
-      matcher = /\A(?<title>.+)\s(?<time clause>\(for\s.*[minutes|hours]\))(?<addon>.*)\Z/i
+      matcher = /\A(?<title>#{task.title.strip})\s*(?<addon>.*)\Z/i
       google_title = matcher.match(google_task.title).named_captures.fetch("title", nil)&.downcase&.strip
       google_title == task.title&.downcase&.strip
     end

--- a/lib/google_tasks/service.rb
+++ b/lib/google_tasks/service.rb
@@ -133,7 +133,7 @@ module GoogleTasks
 
     # In case a reclaim title is present, match the title
     def friendly_titles_match?(google_task, task)
-      matcher = /\A(?<title>.+)\s*(?<addon>.*)\Z/i
+      matcher = /\A(?<title>.+)\s(?<time clause>\(for\s.*[minutes|hours]\))(?<addon>.*)\Z/i
       google_title = matcher.match(google_task.title).named_captures.fetch("title", nil)&.downcase&.strip
       google_title == task.title&.downcase&.strip
     end


### PR DESCRIPTION
When a time estimate is added in Omnifocus a time clause (`(for x minutes)`) is added to the task when it is pushed to google tasks. Presumably, this to the accomodate the GoogleTask <--> Reclaim.ai sync. However, this is added to the task title. This causes the titles not to match on subsequent sync, which was causing the task to be repeatedly pushed to Google as a new task.