### PR TITLE
Add a sync_id (and url) to notes when syncing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,8 +60,6 @@ group :development do
   gem "pry" # https://github.com/pry/pry
   gem "rubocop"
   gem "rubocop-performance"
-  gem "ruby-lsp", "~> 0.4.1", require: false
-  gem "solargraph"
   gem "standard"
 end
 

--- a/lib/asana/service.rb
+++ b/lib/asana/service.rb
@@ -11,85 +11,20 @@ module Asana
       @personal_access_token = ENV.fetch("ASANA_PERSONAL_ACCESS_TOKEN", nil)
     end
 
+    def item_class
+      Task
+    end
+
     def friendly_name
       "Asana"
     end
 
-    # For new tasks on either service, creates new matching ones
-    # for existing tasks, first check for an updated_at timestamp
-    # and sync from the service with the newer modification
-    def sync_with_primary(primary_service)
-      return @last_sync_data unless should_sync?
-
-      primary_tasks = primary_service.tasks_to_sync(tags: [friendly_name])
-      asana_tasks = tasks_to_sync
-      # Step 1: pair tasks that have matching sync_ids
-      paired_tasks = {}
-      primary_tasks.each do |primary_task|
-        matching_task = asana_tasks.find { |asana_task| (asana_task.sync_id == primary_task.id) || (asana_task.id == primary_task.sync_id) }
-        paired_tasks[primary_task] = matching_task if matching_task
-      end
-      unmatched_primary_tasks = primary_tasks - paired_tasks.keys
-      unmatched_asana_tasks = asana_tasks - paired_tasks.values
-      tasks_grouped_by_title = (unmatched_primary_tasks + unmatched_asana_tasks).group_by { |task| task.title.downcase.strip }
-      unless options[:quiet]
-        progressbar = ProgressBar.create(format: "%t: %c/%C |%w>%i| %e ",
-                                         total: paired_tasks.length + tasks_grouped_by_title.length,
-                                         title: "#{primary_service.class.name} syncing with Asana")
-      end
-      paired_tasks.each do |primary_task, asana_task|
-        if primary_task.updated_at > asana_task.updated_at
-          update_task(asana_task, primary_task)
-        else
-          primary_service.update_task(primary_task, asana_task)
-        end
-      end
-      tasks_grouped_by_title.each do |_title, tasks|
-        output = case tasks.length
-                 when 1
-                   task = tasks.first
-                   if task.instance_of?(Asana::Task)
-                     unless task.assignee == asana_user["gid"] || task.assignee.nil?
-                       # Skip creating new tasks that are not assigned to the owner of the Personal Access Token
-                       # Unassigned tasks are fine to create as well
-                       progressbar.increment unless options[:quiet]
-                       next
-                     end
-                     primary_service.add_task(task) unless task.completed?
-                   else # task is a primary_service task
-                     add_task(task) unless task.completed?
-                   end
-                 when 2 # task already exists
-                   newer_task = tasks.max_by(&:updated_at)
-                   older_task = tasks.min_by(&:updated_at)
-                   if should_sync?(newer_task.updated_at)
-                     if newer_task.instance_of?(Asana::Task) && !older_task.instance_of?(Asana::Task)
-                       primary_service.update_task(older_task, newer_task)
-                     elsif newer_task.instance_of?(Asana::Task) && older_task.instance_of?(Asana::Task)
-                       primary_service.add_task(older_task) unless older_task.completed?
-                       primary_service.add_task(newer_task) unless newer_task.completed?
-                     elsif !newer_task.instance_of?(Asana::Task) && !older_task.instance_of?(Asana::Task)
-                       add_task(older_task) unless older_task.completed?
-                       add_task(newer_task) unless newer_task.completed?
-                     else
-                       update_task(older_task, newer_task)
-                     end
-                   elsif options[:debug]
-                     debug("Skipping sync of #{newer_task.title} (should_sync? == false)")
-                   end
-                 else
-                   puts tasks.map(&:title)
-          # raise "Too many tasks!"
-        end
-        progressbar.log "#{self.class}##{__method__}: #{output}" if !output.blank? && ((options[:pretend] && options[:verbose] && !options[:quiet]) || options[:debug])
-        progressbar.increment unless options[:quiet]
-      end
-      puts "Synced #{paired_tasks.length + tasks_grouped_by_title.length} #{options[:primary]} and Asana items" unless options[:quiet]
-      { service: friendly_name, last_attempted: options[:sync_started_at], last_successful: options[:sync_started_at], items_synced: paired_tasks.length + tasks_grouped_by_title.length }.stringify_keys
+    def sync_strategies
+      [:two_way]
     end
 
     # Asana doesn't use tags or an inbox, so just get all tasks in the requested project
-    def tasks_to_sync(*)
+    def items_to_sync(*)
       visible_project_gids = list_projects.map { |project| project["gid"] }
       task_list = visible_project_gids.map { |project_gid| list_project_tasks(project_gid) }.flatten.uniq
       tasks = task_list.map { |task| Task.new(asana_task: task, options:) }
@@ -109,9 +44,9 @@ module Asana
       end
       tasks
     end
-    memo_wise :tasks_to_sync
+    memo_wise :items_to_sync
 
-    def add_task(external_task, parent_task_gid = nil)
+    def add_item(external_task, parent_task_gid = nil)
       debug("external_task: #{external_task}, parent_task_gid: #{parent_task_gid}") if options[:debug]
       request_body = {
         query: { opt_fields: Task.requested_fields.join(",") },
@@ -142,7 +77,7 @@ module Asana
       end
     end
 
-    def update_task(asana_task, external_task)
+    def update_item(asana_task, external_task)
       debug("asana_task: #{asana_task.title}") if options[:debug]
       request_body = {
         query: { opt_fields: Task.requested_fields.join(",") },
@@ -186,6 +121,18 @@ module Asana
       5.minutes.to_i
     end
 
+    # Defines the conditions under which a task should be not be created,
+    # either in the primary_service or in Asana
+    def skip_create?(task)
+      return true if task.completed?
+
+      # Don't create a task in the primary service if the Asana task
+      # is assigned to someone other than the API user
+      return true if task.instance_of?(item_class) && (task.assignee == asana_user["gid"] || task.assignee.nil?)
+
+      false
+    end
+
     # create or update subtasks on a task
     def handle_subtasks(asana_task, external_task)
       debug("") if options[:debug]
@@ -193,10 +140,10 @@ module Asana
 
       external_task.subtasks.each do |subtask|
         if (existing_task = asana_task.subtasks.find { |asana_subtask| friendly_titles_match?(asana_subtask, subtask) })
-          update_task(existing_task, subtask)
+          update_item(existing_task, subtask)
           "Updated subtask #{subtask.title} of task #{external_task.title} in Asana"
         else
-          add_task(subtask, asana_task.id) unless subtask.completed?
+          add_item(subtask, asana_task.id) unless subtask.completed?
           "Created subtask #{subtask.title} of task #{external_task.title} in Asana"
         end
       end

--- a/lib/asana/task.rb
+++ b/lib/asana/task.rb
@@ -54,10 +54,6 @@ module Asana
       true
     end
 
-    def sync_notes
-      notes_with_values(notes, sync_id:, url:)
-    end
-
     # fields required for Asana
     def to_json(*)
       {
@@ -73,6 +69,10 @@ module Asana
           projects: [project["gid"]]
         }.compact
       }.to_json
+    end
+
+    def sync_url
+      url
     end
 
     #       #####

--- a/lib/base/service.rb
+++ b/lib/base/service.rb
@@ -12,8 +12,73 @@ module Base
       @last_sync_data = options[:logger].sync_data_for(friendly_name)
     end
 
+    def item_class
+      raise "not implemented"
+    end
+
     def friendly_name
       raise "not implemented"
+    end
+
+    # This method returns a list of strategies that the service supports. There are 3 strategies:
+    # * :two_way - the service supports syncing items in both directions using the `sync_with_primary` method
+    # * :from_primary - the service supports syncing items from the primary service to the service using the `sync_from_primary` method
+    # * :to_primary - the service supports syncing items from the service to the primary service using the `sync_to_primary` method
+    def sync_strategies
+      raise "not implemented"
+    end
+
+    # Implements the :two_way sync strategy
+    # Steps for a two way sync:
+    # 1. Check if enough time has passed since the previous sync attempt
+    # 2. Gather the list of items for the current service and the primary service for comparison
+    # 3. Pair up matching items in the primary and current services
+    # 3a. First try to match items using their sync_id
+    # 3b. If no match is found, try to match items using their title (and notes if necessary)
+    # 4. With items paired by sync_id, check which item is newer and sync it to the other service
+    # 5. For items grouped by title, check how many items are in the group
+    # 5a. If there is only a single item, sync it to the other service as a new item
+    # 5b. If there are 2 items, sync the newer item to the other service - also update the sync_ids
+    # 5c. If there are more than 2 items, match as many attributes as possible between items and treat them as a pair adding sync_ids. (TODO: It might be better to just treat each side as a new item and create duplicates? Maybe there should be a setting for this)
+    # 6. Update the sync_log and return results
+    def sync_with_primary(primary_service)
+      return @last_sync_data unless should_sync?
+
+      primary_items = primary_service.items_to_sync(tags: [friendly_name])
+      service_items = items_to_sync
+      paired_items = items_paired_by_sync_id(primary_items, service_items)
+      unmatched_primary_items = primary_items - paired_items.flatten
+      unmatched_service_items = service_items - paired_items.flatten
+      paired_items << items_grouped_by_title(unmatched_primary_items + unmatched_service_items)
+      unmatched_primary_items -= paired_items.flatten
+      unmatched_service_items -= paired_items.flatten
+      item_count = (paired_items.length / 2) + unmatched_primary_items.length + unmatched_service_items.length
+      unless options[:quiet]
+        progressbar = ProgressBar.create(
+          format: "%t: %c/%C |%w>%i| %e ",
+          total: item_count,
+          title: "#{primary_service.class.name} syncing with #{friendly_name}"
+        )
+      end
+      paired_items.each do |pair|
+        older_item, newer_item = pair
+        if newer_item.instance_of?(primary_service.item_class)
+          update_item(older_item, newer_item)
+        else
+          primary_service.update_item(older_item, newer_item)
+        end
+        progressbar.increment unless options[:quiet]
+      end
+      unmatched_primary_items.each do |item|
+        add_item(item) unless skip_create?(item)
+        progressbar.increment unless options[:quiet]
+      end
+      unmatched_service_items.each do |item|
+        primary_service.add_item(item) unless skip_create?(item)
+        progressbar.increment unless options[:quiet]
+      end
+      puts "Synced #{item_count} #{options[:primary]} and #{friendly_name} items" unless options[:quiet]
+      { service: friendly_name, last_attempted: options[:sync_started_at], last_successful: options[:sync_started_at], items_synced: item_count }.stringify_keys
     end
 
     def should_sync?(item_updated_at = nil)
@@ -27,11 +92,64 @@ module Base
       end
     end
 
+    def sync_to_primary(_primary_service)
+      items = items_to_sync
+    end
+
     private
+
+    # creates items pairs based on sync_ids
+    # `items_to_sync` should be defined in the service subclass
+    def items_paired_by_sync_id(primary_items, service_items)
+      item_pairs = []
+      primary_items.each do |primary_item|
+        matching_item = service_items.find { |item| item.sync_id == primary_item.id || item.id == primary_item.sync_id }
+        item_pairs << [primary_item, matching_item].sort_by(&:updated_at) if matching_item
+      end
+      item_pairs
+    end
+    memo_wise :items_paired_by_sync_id
+
+    # creates item groups based on title and notes
+    # should be used when items don't have sync_ids
+    def items_grouped_by_title(items)
+      item_pairs = []
+      title_grouping = items.group_by { |item| item.title.downcase.strip }
+      title_grouping.each do |_title, title_group|
+        if (title_group.length == 2) && (title_group.first.class != title_group.last.class)
+          item_pairs << title_group.sort_by(&:updated_at)
+        else
+          notes_grouping = title_group.group_by { |item| item.notes.downcase.strip }
+          notes_grouping.each_value do |notes_group|
+            if (notes_group.length == 2) && (notes_group.first.class != notes_group.last.class)
+              item_pairs << notes_group.sort_by(&:updated_at)
+            elsif notes_group.length > 2
+              # in this case, we have multiple items with the same title and notes (probably blank)
+              # We can either try to match on other attributes (type dependent) or just treat them as duplicates
+              # For now, we'll just treat them as duplicates and randomly pair some up
+              service_items = notes_group.select { |item| item.instance_of?(item_class) }
+              primary_items = notes_group - service_items
+              item_pairs << [primary_items.pop, service_items.pop].sort_by(&:updated_at) while primary_items.length.positive? && service_items.length.positive?
+            end
+          end
+        end
+      end
+      item_pairs
+    end
+    memo_wise :items_grouped_by_title
 
     # the default minimum time we should wait between syncing items
     def min_sync_interval
       raise "not implemented"
+    end
+
+    # Defines the conditions under which a task should be not be created,
+    # either in the primary_service or in the current service
+    def skip_create?(item)
+      # Never create new completed items
+      return true if item.completed?
+
+      false
     end
   end
 end

--- a/lib/base/sync_item.rb
+++ b/lib/base/sync_item.rb
@@ -39,7 +39,7 @@ module Base
     end
 
     def sync_notes
-      notes_with_values(notes, sync_id:, sync_url:)
+      notes_with_values(notes, sync_id:, url: sync_url)
     end
 
     def to_s
@@ -57,11 +57,6 @@ module Base
 
     def default_tags
       options[:tags] + [provider]
-    end
-
-    # Subclasses should override this
-    def attribute_map
-      raise "Not implemented"
     end
 
     def standard_attribute_map

--- a/lib/debug.rb
+++ b/lib/debug.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 module Debug
-  def debug(message)
+  def debug(message, debug_option = ENV.fetch("DEBUG", false))
+    return unless debug_option
+
     puts "#{caller_locations(1, 1)}: #{message}"
   end
 end

--- a/lib/github/issue.rb
+++ b/lib/github/issue.rb
@@ -23,6 +23,7 @@ module Github
         status: "state",
         tags: nil,
         url: "html_url",
+        notes: "body",
         updated_at: nil
       }
     end
@@ -41,6 +42,10 @@ module Github
 
     def friendly_title
       "#{project}-##{number}: #{is_pr ? '[PR] ' : ''}#{title.strip}"
+    end
+
+    def sync_url
+      url
     end
 
     #       #####

--- a/lib/instapaper/authentication.rb
+++ b/lib/instapaper/authentication.rb
@@ -14,7 +14,7 @@ module Instapaper
     end
 
     def authenticate!
-      debug("Called") if options[:debug]
+      debug("Called", options[:debug])
       params = {
         site: "https://www.instapaper.com/api/1",
         scheme: :header,

--- a/lib/instapaper/service.rb
+++ b/lib/instapaper/service.rb
@@ -28,40 +28,17 @@ module Instapaper
       "Instapaper"
     end
 
-    # Instapaper only syncs TO another service
-    def sync_to_primary(primary_service)
-      articles = unread_and_recent_articles
-      existing_tasks = primary_service.items_to_sync(tags: [friendly_name], inbox: true)
-      unless options[:quiet]
-        progressbar = ProgressBar.create(
-          format: "%t: %c/%C |%w>%i| %e ",
-          total: articles.length,
-          title: "Instapaper articles"
-        )
-      end
-      articles.each do |article|
-        puts "\n\n#{self.class}##{__method__} Looking for #{article.friendly_title} (#{article.folder})" if options[:debug]
-        output = if (existing_task = existing_tasks.find do |task|
-                       article.friendly_title.downcase == task.title.downcase.strip
-                     end)
-          if should_sync?(article.updated_at)
-            primary_service.update_item(existing_task, article)
-          elsif options[:debug]
-            debug("Skipping sync of #{article.title} (should_sync? == false)")
-          end
-        elsif article.unread?
-          article.read_time(self)
-          primary_service.add_item(article, options)
-        end
-        progressbar.log "#{self.class}##{__method__}: #{output}" if !output.blank? && ((options[:pretend] && options[:verbose] && !options[:quiet]) || options[:debug])
-        progressbar.increment unless options[:quiet]
-      end
-      puts "Synced #{articles.length} Instapaper articles to #{options[:primary]}" unless options[:quiet]
-      { service: friendly_name, last_attempted: options[:sync_started_at], last_successful: options[:sync_started_at], items_synced: articles.length }.stringify_keys
+    def sync_strategies
+      [:to_primary]
     end
 
+    def items_to_sync(*)
+      (unread_articles + recently_archived_articles).uniq(&:id)
+    end
+    memo_wise :items_to_sync
+
     def article_text(article)
-      puts "Getting article fulltext for article: #{article.title}" if options[:debug]
+      debug("Getting article fulltext for article: #{article.title}", options[:debug])
       params = {
         bookmark_id: article.id
       }
@@ -81,13 +58,8 @@ module Instapaper
       30.minutes.to_i
     end
 
-    def unread_and_recent_articles
-      (unread_articles + recently_archived_articles).uniq(&:id)
-    end
-    memo_wise :unread_and_recent_articles
-
     def recently_archived_articles
-      puts "Getting recently archived Instapaper articles" if options[:debug]
+      debug("Getting recently archived Instapaper articles", options[:debug])
       params = {
         limit: ARCHIVED_ARTICLE_COUNT,
         folder_id: "archive"
@@ -103,7 +75,7 @@ module Instapaper
     memo_wise :recently_archived_articles
 
     def unread_articles
-      puts "Getting unread Instapaper articles" if options[:debug]
+      debug("Getting unread Instapaper articles", options[:debug])
       params = { limit: UNREAD_ARTICLE_COUNT }
       response = authentication.get("/bookmarks/list?#{URI.encode_www_form(params)}")
       raise "#{response.code} There was a problem with the Instapaper request" unless response.code.to_i == 200

--- a/lib/instapaper/service.rb
+++ b/lib/instapaper/service.rb
@@ -20,6 +20,10 @@ module Instapaper
       nil
     end
 
+    def item_class
+      Article
+    end
+
     def friendly_name
       "Instapaper"
     end
@@ -27,7 +31,7 @@ module Instapaper
     # Instapaper only syncs TO another service
     def sync_to_primary(primary_service)
       articles = unread_and_recent_articles
-      existing_tasks = primary_service.tasks_to_sync(tags: [friendly_name], inbox: true)
+      existing_tasks = primary_service.items_to_sync(tags: [friendly_name], inbox: true)
       unless options[:quiet]
         progressbar = ProgressBar.create(
           format: "%t: %c/%C |%w>%i| %e ",
@@ -41,13 +45,13 @@ module Instapaper
                        article.friendly_title.downcase == task.title.downcase.strip
                      end)
           if should_sync?(article.updated_at)
-            primary_service.update_task(existing_task, article)
+            primary_service.update_item(existing_task, article)
           elsif options[:debug]
             debug("Skipping sync of #{article.title} (should_sync? == false)")
           end
         elsif article.unread?
           article.read_time(self)
-          primary_service.add_task(article, options)
+          primary_service.add_item(article, options)
         end
         progressbar.log "#{self.class}##{__method__}: #{output}" if !output.blank? && ((options[:pretend] && options[:verbose] && !options[:quiet]) || options[:debug])
         progressbar.increment unless options[:quiet]

--- a/lib/omnifocus/task.rb
+++ b/lib/omnifocus/task.rb
@@ -140,6 +140,10 @@ module Omnifocus
     end
     memo_wise :containers
 
+    def sync_url
+      "omnifocus:///task/#{id}"
+    end
+
     # start_at is a "premium" feature, apparently
     def to_asana
       {

--- a/lib/reclaim/task.rb
+++ b/lib/reclaim/task.rb
@@ -56,7 +56,7 @@ module Reclaim
       type == "PERSONAL"
     end
 
-    def to_json(*_args)
+    def to_h(*_args)
       {
         title:,
         eventColor: nil,
@@ -69,7 +69,11 @@ module Reclaim
         notes:,
         priority: "DEFAULT",
         alwaysPrivate: always_private
-      }.to_json
+      }
+    end
+
+    def to_json(*_args)
+      to_h.to_json
     end
 
     class << self

--- a/lib/reclaim/task.rb
+++ b/lib/reclaim/task.rb
@@ -4,6 +4,9 @@ require_relative "../base/sync_item"
 
 module Reclaim
   class Task < Base::SyncItem
+    PERSONAL = "PERSONAL"
+    WORK = "WORK"
+
     attr_reader :time_required, :time_spent, :time_remaining, :minimum_chunk_size, :maximum_chunk_size, :always_private
 
     def initialize(reclaim_task:, options:)
@@ -41,7 +44,7 @@ module Reclaim
       "Reclaim"
     end
 
-    def complete?
+    def completed?
       time_remaining <= 0
     end
 

--- a/lib/reminders/reminder.rb
+++ b/lib/reminders/reminder.rb
@@ -58,6 +58,13 @@ module Reminders
       "#{provider}::Reminder:(#{id})#{title}"
     end
 
+    def update_attributes(attributes)
+      attributes.each do |key, value|
+        original_attribute_key = inverted_attributes[key]
+        original_task.send(original_attribute_key.to_sym).set(value)
+      end
+    end
+
     # start_at is a "premium" feature, apparently
     def to_asana
       {

--- a/lib/reminders/service.rb
+++ b/lib/reminders/service.rb
@@ -13,6 +13,10 @@ module Reminders
       @reminders_app = Appscript.app.by_name(tag_name)
     end
 
+    def item_class
+      Reminder
+    end
+
     def tag_name
       "Reminders"
     end
@@ -21,19 +25,19 @@ module Reminders
     # for existing tasks, first check for an updated_at timestamp
     # and sync from the service with the newer modification
     def sync_with_primary(primary_service)
-      tasks = primary_service.tasks_to_sync(tags: [tag_name])
-      existing_tasks = tasks_to_sync
+      tasks = primary_service.items_to_sync(tags: [tag_name])
+      existing_tasks = items_to_sync
     end
 
-    def tasks_to_sync(*)
+    def items_to_sync(*)
       sync_maps = options[:reminders_mapping].split(",").map { |mapping| mapping.split("|") }
       reminders_lists = sync_maps.map(&:first)
     end
-    memo_wise :tasks_to_sync
+    memo_wise :items_to_sync
 
-    def add_task(external_task, options = {}, parent_object = nil); end
+    def add_item(external_task, options = {}, parent_object = nil); end
 
-    def update_task(reminder, external_task); end
+    def update_item(reminder, external_task); end
 
     private
 

--- a/lib/reminders/service.rb
+++ b/lib/reminders/service.rb
@@ -56,7 +56,5 @@ module Reminders
       list.reminders_app.get
     end
     memo_wise :reminders_in_list
-
-    def friendly_titles_match?(reminder, external_task); end
   end
 end

--- a/lib/structured_logger.rb
+++ b/lib/structured_logger.rb
@@ -17,12 +17,12 @@ class StructuredLogger
   end
 
   def sync_data_for(service_name)
-    debug("service_name: #{service_name}") if options[:debug]
+    debug("service_name: #{service_name}", options[:debug])
     @existing_logs.find { |log_hash| log_hash["service"] == service_name }
   end
 
   def last_synced(service_name, interval: false)
-    debug("service_name: #{service_name}, interval: #{interval}") if options[:debug]
+    debug("service_name: #{service_name}, interval: #{interval}", options[:debug])
     raw_sync_data = sync_data_for(service_name)
     return if raw_sync_data.nil?
 
@@ -43,7 +43,7 @@ class StructuredLogger
   end
 
   def save_service_log!(service_logs)
-    debug("service_logs.count: #{service_logs.count}") if options[:debug]
+    debug("service_logs.count: #{service_logs.count}", options[:debug])
     return if service_logs.empty?
 
     output = service_logs.map do |service_log|

--- a/lib/task_bridge.rb
+++ b/lib/task_bridge.rb
@@ -48,7 +48,7 @@ class TaskBridge
       opt :verbose, "Verbose output", default: false
       conflicts :quiet, :verbose
       opt :log_file, "File name for service log", default: ENV.fetch("LOG_FILE", "service_sync.log")
-      opt :debug, "Print debug output", default: false
+      opt :debug, "Print debug output", default: ENV.fetch("DEBUG", false)
       opt :console, "Run live console session", default: false
       opt :history, "Print sync service history", default: false
       opt :testing, "For testing purposes only", default: false
@@ -79,9 +79,9 @@ class TaskBridge
         @service_logs << { service: service.friendly_name, last_attempted: @options[:sync_started_at] }.stringify_keys
       elsif @options[:delete]
         service.prune if service.respond_to?(:prune)
-      elsif @options[:only_to_primary] && service.respond_to?(:sync_to_primary)
+      elsif @options[:only_to_primary] && service.sync_strategies.include?(:to_primary)
         @service_logs << service.sync_to_primary(@primary_service)
-      elsif @options[:only_from_primary] && service.respond_to?(:sync_from_primary)
+      elsif @options[:only_from_primary] && service.sync_strategies.include?(:from_primary)
         @service_logs << service.sync_from_primary(@primary_service)
       elsif service.sync_strategies.include?(:two_way)
         # if the #sync_with_primary method exists, we should use it unless options force us not to

--- a/lib/task_bridge.rb
+++ b/lib/task_bridge.rb
@@ -83,14 +83,14 @@ class TaskBridge
         @service_logs << service.sync_to_primary(@primary_service)
       elsif @options[:only_from_primary] && service.respond_to?(:sync_from_primary)
         @service_logs << service.sync_from_primary(@primary_service)
-      elsif service.respond_to?(:sync_with_primary)
+      elsif service.sync_strategies.include?(:two_way)
         # if the #sync_with_primary method exists, we should use it unless options force us not to
         @service_logs << service.sync_with_primary(@primary_service)
       else
         # Generally we should sync FROM the primary service first, since it should be the source of truth
         # and we want to avoid overwriting anything in the primary service if a duplicate task exists
-        @service_logs << service.sync_from_primary(@primary_service) if service.respond_to?(:sync_from_primary)
-        @service_logs << service.sync_to_primary(@primary_service) if service.respond_to?(:sync_to_primary)
+        @service_logs << service.sync_from_primary(@primary_service) if service.sync_strategies.include?(:from_primary)
+        @service_logs << service.sync_to_primary(@primary_service) if service.sync_strategies.include?(:to_primary)
       end
       @options[:logger].save_service_log!(@service_logs)
     end

--- a/spec/lib/asana/service_spec.rb
+++ b/spec/lib/asana/service_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "Asana::Service" do
     end
   end
 
-  describe "#tasks_to_sync" do
-    subject { service.tasks_to_sync }
+  describe "#items_to_sync" do
+    subject { service.items_to_sync }
   end
 
   describe "#should_sync?" do
@@ -60,8 +60,8 @@ RSpec.describe "Asana::Service" do
     end
   end
 
-  describe "#add_task" do
-    subject { service.add_task(external_task, parent_task_gid) }
+  describe "#add_item" do
+    subject { service.add_item(external_task, parent_task_gid) }
 
     let(:external_task) { nil }
     let(:parent_task_gid) { nil }
@@ -76,7 +76,7 @@ RSpec.describe "Asana::Service" do
     end
 
     context "with Omnifocus task" do
-      let(:external_task) { Omnifocus::Service.new.tasks_to_sync(projects: "TaskBridge:Test").first }
+      let(:external_task) { Omnifocus::Service.new.items_to_sync(projects: "TaskBridge:Test").first }
 
       context "with a regular task" do
       end
@@ -89,8 +89,8 @@ RSpec.describe "Asana::Service" do
     end
   end
 
-  describe "#update_task" do
-    subject { service.update_task(asana_task, external_task) }
+  describe "#update_item" do
+    subject { service.update_item(asana_task, external_task) }
 
     let(:asana_task) { nil }
     let(:external_task) { nil }

--- a/spec/lib/github/issue_spec.rb
+++ b/spec/lib/github/issue_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Github::Issue" do
+  let(:service) { Github::Service.new }
+  let(:issue) { Github::Issue.new(github_issue: properties, options:) }
+  let(:options) { { tags: [] } }
+  let(:id) { Faker::Number.number(digits: 10) }
+  let(:number) { Faker::Number.number(digits: 3) }
+  let(:title) { Faker::Lorem.sentence }
+  let(:repo_url) { "https://api.github.com/repos/viamin/task_bridge" }
+  let(:url) { "#{repo_url}/issues/#{number}" }
+  let(:body) { "body" }
+  let(:status) { "open" }
+  let(:labels) { [] }
+  let(:start_date) { "Today" }
+  let(:due_date) { "Tomorrow" }
+  let(:properties) do
+    {
+      "id" => id,
+      "number" => number,
+      "title" => title,
+      "html_url" => url,
+      "repository_url" => repo_url,
+      "body" => body,
+      "state" => status,
+      "labels" => labels
+    }.compact
+  end
+
+  it "is marked open" do
+    expect(issue).to be_open
+  end
+
+  context "when status is closed" do
+    let(:status) { "closed" }
+
+    it "is marked completed" do
+      expect(issue).to be_completed
+    end
+  end
+
+  describe "#sync_notes" do
+    let(:notes) { "notes\n\nsync_id: #{id}\n" }
+
+    it "adds a sync_url to the notes" do
+      expect(issue.notes).to eq("body")
+      expect(issue.sync_url).to eq("#{repo_url}/issues/#{number}")
+      expect(issue.sync_notes).to eq("body\n\nurl: #{repo_url}/issues/#{number}\n")
+    end
+  end
+end

--- a/spec/lib/github/service_spec.rb
+++ b/spec/lib/github/service_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "Github::Service" do
     end
   end
 
-  describe "#tasks_to_sync" do
-    subject { service.tasks_to_sync }
+  describe "#items_to_sync" do
+    subject { service.items_to_sync }
   end
 
   describe "#should_sync?" do
@@ -60,8 +60,8 @@ RSpec.describe "Github::Service" do
     end
   end
 
-  describe "#add_task" do
-    subject { service.add_task(external_task, parent_task_gid) }
+  describe "#add_item" do
+    subject { service.add_item(external_task, parent_task_gid) }
 
     let(:external_task) { nil }
     let(:parent_task_gid) { nil }
@@ -76,7 +76,7 @@ RSpec.describe "Github::Service" do
     end
 
     context "with Omnifocus task" do
-      let(:external_task) { Omnifocus::Service.new.tasks_to_sync(projects: "TaskBridge:Test").first }
+      let(:external_task) { Omnifocus::Service.new.items_to_sync(projects: "TaskBridge:Test").first }
 
       context "with a regular task" do
       end
@@ -89,8 +89,8 @@ RSpec.describe "Github::Service" do
     end
   end
 
-  describe "#update_task" do
-    subject { service.update_task(instapaper_article, external_task) }
+  describe "#update_item" do
+    subject { service.update_item(instapaper_article, external_task) }
 
     let(:instapaper_article) { nil }
     let(:external_task) { nil }

--- a/spec/lib/google_tasks/service_spec.rb
+++ b/spec/lib/google_tasks/service_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "GoogleTasks::Service" do
   let(:httparty_success_mock) { OpenStruct.new(success?: true, body: { data: { task: external_task.to_json } }.to_json) }
 
   before do
+    allow_any_instance_of(GoogleTasks::BaseCli).to receive(:user_credentials_for).and_return({})
     allow(logger).to receive(:sync_data_for).and_return({})
     allow(logger).to receive(:last_synced).and_return(last_sync)
   end
@@ -19,8 +20,8 @@ RSpec.describe "GoogleTasks::Service" do
     context "with omnifocus" do
       let(:primary_service) { Omnifocus::Service.new(options: {}) }
 
-      it "responds to #sync_from_primary", :no_ci do
-        expect(service).to be_respond_to(:sync_from_primary)
+      it "syncs from primary" do
+        expect(service.sync_strategies).to contain_exactly(:from_primary)
       end
     end
   end
@@ -35,26 +36,26 @@ RSpec.describe "GoogleTasks::Service" do
     context "when task_updated_at is nil" do
       let(:task_updated_at) { nil }
 
-      context "when last sync was less than min_sync_interval", :no_ci do
+      context "when last sync was less than min_sync_interval" do
         let(:last_sync) { Time.now - Chronic.parse("29 minutes ago") }
 
         it { is_expected.to be false }
       end
 
-      context "when last sync was more than min_sync_interval", :no_ci do
+      context "when last sync was more than min_sync_interval" do
         let(:last_sync) { Time.now - Chronic.parse("31 minutes ago") }
 
         it { is_expected.to be true }
       end
     end
 
-    context "when task_updated_at is less than min_sync_interval", :no_ci do
+    context "when task_updated_at is less than min_sync_interval" do
       let(:task_updated_at) { Chronic.parse("29 minutes ago") }
 
       it { is_expected.to be true }
     end
 
-    context "when task_updated_at is more than min_sync_interval", :no_ci do
+    context "when task_updated_at is more than min_sync_interval" do
       let(:task_updated_at) { Chronic.parse("31 minutes ago") }
 
       it { is_expected.to be false }
@@ -96,7 +97,7 @@ RSpec.describe "GoogleTasks::Service" do
     let(:google_task) { nil }
     let(:external_task) { nil }
 
-    it "raises an error", :no_ci do
+    it "raises an error" do
       expect { subject }.to raise_error NoMethodError
     end
   end

--- a/spec/lib/google_tasks/service_spec.rb
+++ b/spec/lib/google_tasks/service_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe "GoogleTasks::Service" do
     end
   end
 
-  describe "#tasks_to_sync" do
-    subject { service.tasks_to_sync }
+  describe "#items_to_sync" do
+    subject { service.items_to_sync }
   end
 
   describe "#should_sync?" do
@@ -61,8 +61,8 @@ RSpec.describe "GoogleTasks::Service" do
     end
   end
 
-  describe "#add_task" do
-    subject { service.add_task(tasklist, external_task, parent_task_gid) }
+  describe "#add_item" do
+    subject { service.add_item(tasklist, external_task, parent_task_gid) }
 
     let(:external_task) { nil }
     let(:parent_task_gid) { nil }
@@ -77,7 +77,7 @@ RSpec.describe "GoogleTasks::Service" do
     end
 
     context "with Omnifocus task" do
-      let(:external_task) { Omnifocus::Service.new.tasks_to_sync(projects: "TaskBridge:Test").first }
+      let(:external_task) { Omnifocus::Service.new.items_to_sync(projects: "TaskBridge:Test").first }
 
       context "with a regular task" do
       end
@@ -90,8 +90,8 @@ RSpec.describe "GoogleTasks::Service" do
     end
   end
 
-  describe "#update_task" do
-    subject { service.update_task(tasklist, google_task, external_task, options) }
+  describe "#update_item" do
+    subject { service.update_item(tasklist, google_task, external_task, options) }
 
     let(:google_task) { nil }
     let(:external_task) { nil }

--- a/spec/lib/instapaper/service_spec.rb
+++ b/spec/lib/instapaper/service_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe "Instapaper::Service" do
     end
   end
 
-  describe "#tasks_to_sync" do
-    subject { service.tasks_to_sync }
+  describe "#items_to_sync" do
+    subject { service.items_to_sync }
   end
 
   describe "#should_sync?" do
@@ -64,8 +64,8 @@ RSpec.describe "Instapaper::Service" do
     end
   end
 
-  describe "#add_task" do
-    subject { service.add_task(external_task, parent_task_gid) }
+  describe "#add_item" do
+    subject { service.add_item(external_task, parent_task_gid) }
 
     let(:external_task) { nil }
     let(:parent_task_gid) { nil }
@@ -80,7 +80,7 @@ RSpec.describe "Instapaper::Service" do
     end
 
     context "with Omnifocus task" do
-      let(:external_task) { Omnifocus::Service.new.tasks_to_sync(projects: "TaskBridge:Test").first }
+      let(:external_task) { Omnifocus::Service.new.items_to_sync(projects: "TaskBridge:Test").first }
 
       context "with a regular task" do
       end
@@ -93,8 +93,8 @@ RSpec.describe "Instapaper::Service" do
     end
   end
 
-  describe "#update_task" do
-    subject { service.update_task(instapaper_article, external_task) }
+  describe "#update_item" do
+    subject { service.update_item(instapaper_article, external_task) }
 
     let(:instapaper_article) { nil }
     let(:external_task) { nil }

--- a/spec/lib/omnifocus/service_spec.rb
+++ b/spec/lib/omnifocus/service_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "Omnifocus::Service" do
     allow(logger).to receive(:last_synced).and_return(last_sync)
   end
 
-  describe "#tasks_to_sync" do
-    subject { service.tasks_to_sync(tags:, projects:, folder:, inbox:, incomplete_only:) }
+  describe "#items_to_sync" do
+    subject { service.items_to_sync(tags:, projects:, folder:, inbox:, incomplete_only:) }
 
     let(:tags) { nil }
     let(:projects) { nil }
@@ -38,7 +38,7 @@ RSpec.describe "Omnifocus::Service" do
       let(:projects) { "TaskBridge" }
 
       it "returns tasks in a project", :no_ci do
-        expect(subject.count).to eq(4)
+        expect(subject.count).to eq(3)
       end
     end
 
@@ -46,7 +46,7 @@ RSpec.describe "Omnifocus::Service" do
       let(:folder) { "TaskBridge" }
 
       it "returns all tasks in a folder", :no_ci do
-        expect(subject.count).to eq(6)
+        expect(subject.count).to eq(5)
       end
     end
 
@@ -59,9 +59,9 @@ RSpec.describe "Omnifocus::Service" do
     end
   end
 
-  describe "#add_task" do
+  describe "#add_item" do
   end
 
-  describe "#update_task" do
+  describe "#update_item" do
   end
 end

--- a/spec/lib/omnifocus/task_spec.rb
+++ b/spec/lib/omnifocus/task_spec.rb
@@ -61,12 +61,13 @@ RSpec.describe "Omnifocus::Task" do
   end
 
   describe "#sync_notes" do
-    let(:notes) { "notes\n\nsync_id: jU466dYHf2o\n" }
+    let(:notes) { "notes\n\nsync_id: #{id}\n" }
 
     it "adds a sync_id to the notes" do
       expect(task.notes).to eq("notes")
-      expect(task.sync_id).to eq("jU466dYHf2o")
-      expect(task.sync_notes).to eq("notes\n\nsync_id: jU466dYHf2o\n")
+      expect(task.sync_id).to eq(id)
+      expect(task.sync_url).to eq("omnifocus:///task/#{id}")
+      expect(task.sync_notes).to eq("notes\n\nsync_id: #{id}\nurl: omnifocus:///task/#{id}\n")
     end
   end
 end

--- a/spec/lib/reclaim/task_spec.rb
+++ b/spec/lib/reclaim/task_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Reclaim::Task" do
+  let(:service) { Reclaim::Service.new }
+  let(:task) { Reclaim::Task.new(reclaim_task: properties, options:) }
+  let(:options) { { tags: [], work_tags: "", personal_tags: "" } }
+  let(:id) { Faker::Number.number(digits: 7) }
+  let(:title) { Faker::Lorem.sentence }
+  let(:notes) { "notes" }
+  let(:start_date) { "Today" }
+  let(:due_date) { "Tomorrow" }
+  let(:event_category) { %w[WORK PERSONAL].sample }
+  let(:properties) do
+    {
+      "id" => id,
+      "title" => title,
+      "due" => due_date,
+      "snoozeUntil" => start_date,
+      "notes" => notes,
+      "eventCategory" => event_category
+    }.compact
+  end
+
+  it "parses the due_date" do
+    expect(task.due_date).to be_instance_of(Time)
+  end
+
+  it "parses the start_date" do
+    expect(task.start_date).to be_instance_of(Time)
+  end
+
+  context "when eventCatgory is personal" do
+    let(:event_category) { Reclaim::Task::PERSONAL }
+
+    it "is personal" do
+      expect(task).to be_personal
+    end
+  end
+
+  describe "#sync_notes" do
+    let(:notes) { "notes\n\nsync_id: #{id}\n" }
+
+    it "adds a sync_id to the notes" do
+      expect(task.notes).to eq("notes")
+      expect(task.sync_id).to eq(id.to_s)
+      expect(task.sync_url).to be_nil
+      expect(task.sync_notes).to eq("notes\n\nsync_id: #{id}\n")
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/viamin/task_bridge/issues/91

Will also try using the sync_id to match items across services, which should allow updates to titles, which was not possible before. 