### PR TITLE
Update documentation based on the missing tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ Most of the command line options can be configured using an environment variable
 
 This script uses AppleScript on your Mac to talk to OmniFocus. OmniFocus needs to be installed on the computer you're running this script on to work.
 
+You'll need to create a "TaskBridge" tag in OmniFocus for sync to work. Additionally, each service you want to sync with OmniFocus requires a matching tag to be created. TaskBridge will not create the tags for you.
+
+Supported services and their tags:
+
+| Service | Tag
+|---------|-----
+| Asana | Asana
+| Github | Github
+| Google Tasks | Google Tasks
+| Instapaper | Instapaper
+| Reclaim.ai | Reclaim
+| Apple Reminders | Reminders
+
+If you forget to add a task for a service, strange things might happen, like duplicate tasks being created. Make sure you have the tags created before you run the script.
+
 ## Github Setup
 
 TaskBridge will sync issues and PRs that are assigned to you or that have a label matching what is configured in the `tags` setting. Issues created in Omnifocus will have the "Github" tag applied.

--- a/lib/base/sync_item.rb
+++ b/lib/base/sync_item.rb
@@ -62,7 +62,7 @@ module Base
 
     # First, check for a matching sync_id, if supported. Then, check for matching titles
     def find_matching_item_in(collection = [])
-      id_match = collection.find { |item| id == item.sync_id } if respond_to?(:id) && sync_id
+      id_match = collection.find { |item| ((item.id && (item.id == sync_id)) || (item.sync_id && (item.sync_id == id))) }
       return id_match if id_match
 
       # This should only match older items that don't have sync_ids

--- a/lib/reminders/reminder.rb
+++ b/lib/reminders/reminder.rb
@@ -57,6 +57,10 @@ module Reminders
     end
     memo_wise :original_reminder
 
+    def external_sync_notes
+      notes_with_values(notes, sync_id: id)
+    end
+
     def friendly_title
       title
     end
@@ -70,10 +74,6 @@ module Reminders
         original_attribute_key = attribute_map[key].to_sym
         original_reminder.send(original_attribute_key).set(value)
       end
-    end
-
-    def url
-      nil
     end
 
     private


### PR DESCRIPTION
which was causing duplicate tasks to be created in Omnifocus for a single reminder