### PR TITLE
Use service specific ids and urls to tag notes

### DIFF
--- a/lib/base/service.rb
+++ b/lib/base/service.rb
@@ -145,13 +145,14 @@ module Base
     end
 
     def update_sync_data(existing_item, sync_id, sync_url = nil)
-      existing_item.sync_id = sync_id
-      existing_item.sync_url = sync_url if sync_url
+      service_name = friendly_name.underscore
+      existing_item.instance_variable_set("@#{service_name}_id", sync_id) if sync_id
+      existing_item.instance_variable_set("@#{service_name}_url", sync_url) if sync_url
       existing_item.update_attributes(notes: existing_item.sync_notes)
     end
 
-    def existing_items(primary_service)
-      primary_service.items_to_sync(tags: [friendly_name], inbox: true)
+    def existing_items(service)
+      service.items_to_sync(tags: [friendly_name], inbox: true)
     end
 
     def items_to_sync(*)

--- a/lib/base/sync_item.rb
+++ b/lib/base/sync_item.rb
@@ -7,26 +7,28 @@ module Base
     include NoteParser
 
     attr_reader :options, :tags, :notes, :debug_data
-    attr_accessor :sync_id, :sync_url
 
     def initialize(sync_item:, options:)
       @options = options
       @debug_data = sync_item if @options[:debug]
       @tags = default_tags
       attributes = standard_attribute_map.merge(attribute_map).compact
+      raw_notes = read_attribute(sync_item, attributes.delete(:notes))
       attributes.each do |attribute_key, attribute_value|
         value = read_attribute(sync_item, attribute_value)
         value = Chronic.parse(value) if chronic_attributes.include?(attribute_key)
         instance_variable_set("@#{attribute_key}", value)
         define_singleton_method(attribute_key.to_sym) { instance_variable_get("@#{attribute_key}") }
       end
+      return if raw_notes.blank?
 
-      parsed_data = parsed_notes(keys: %w[sync_id url], notes: read_attribute(sync_item, attributes[:notes]))
-      return unless parsed_data
-
-      @sync_id = parsed_data["sync_id"]
-      @sync_url = parsed_data["url"]
-      @notes = parsed_data["notes"]
+      all_service_readers = all_services(remove_current: true).map { |service| ["#{service.underscore}_id", "#{service.underscore}_url"] }.flatten
+      note_components = parsed_notes(keys: all_service_readers, notes: raw_notes)
+      note_components.each do |key, value|
+        instance_variable_set("@#{key}", value)
+        define_singleton_method(key.to_sym) { instance_variable_get("@#{key}") }
+        define_singleton_method("#{key}=".to_sym) { |val| instance_variable_set("@#{key}", val) }
+      end
     end
 
     def completed?
@@ -60,9 +62,14 @@ module Base
     end
     memo_wise :service
 
+    def sync_id(service = nil)
+      service ||= provider
+      send("#{service.underscore}_id")
+    end
+
     # First, check for a matching sync_id, if supported. Then, check for matching titles
     def find_matching_item_in(collection = [])
-      id_match = collection.find { |item| ((item.id && (item.id == sync_id)) || (item.sync_id && (item.sync_id == id))) }
+      id_match = collection.find { |item| ((item.id && (item.id == sync_id)) || (item.sync_id(provider) && (item.sync_id(provider) == id))) }
       return id_match if id_match
 
       # This should only match older items that don't have sync_ids
@@ -86,12 +93,18 @@ module Base
     end
 
     def external_sync_notes
-      notes_with_values(notes, sync_id: id, url:)
+      notes_with_values(sync_notes, "#{provider.underscore}_id".to_sym => id, "#{provider.underscore}_url".to_sym => url)
     end
 
     def sync_notes
-      notes_with_values(notes, sync_id:, url: sync_url)
+      service_values = {}
+      all_services(remove_current: true).map do |service|
+        service_values["#{service.underscore}_id"] = instance_variable_get("@#{service.underscore}_id")
+        service_values["#{service.underscore}_url"] = instance_variable_get("@#{service.underscore}_url")
+      end
+      notes_with_values(notes, service_values.compact)
     end
+    memo_wise :sync_notes
 
     def to_s
       "#{provider}::#{self.class.name}: (#{id})#{friendly_title}"
@@ -111,6 +124,13 @@ module Base
     end
 
     private
+
+    def all_services(remove_current: false)
+      all_services = options[:services] + [options[:primary]]
+      all_services.delete(provider) if remove_current
+      all_services
+    end
+    memo_wise :all_services
 
     def default_tags
       options[:tags] + [provider]
@@ -142,6 +162,8 @@ module Base
 
     # read attributes using applescript
     def read_attribute(sync_item, attribute)
+      return if attribute.nil?
+
       value = if sync_item.is_a? Hash
         sync_item.fetch(attribute, nil)
       elsif sync_item.respond_to?(attribute.to_sym)

--- a/lib/google_tasks/task.rb
+++ b/lib/google_tasks/task.rb
@@ -7,24 +7,19 @@ module GoogleTasks
   class Task < Base::SyncItem
     def initialize(google_task:, options:)
       super(sync_item: google_task, options:)
-
-      @project = project_from_memberships(google_task)
-      @sub_item_count = google_task.fetch("num_subtasks", 0).to_i
-      @sub_items = []
-      @assignee = google_task.dig("assignee", "gid")
     end
 
     def attribute_map
       {
-        id: "gid",
-        title: "name",
-        url: "permalink_url",
-        due_date: "due_on",
-        flagged: "hearted",
-        type: "resource_type",
-        start_date: "start_on",
-        updated_at: "modified_at"
+        url: "self_link",
+        due_date: "due",
+        type: "kind",
+        updated_at: "updated"
       }
+    end
+
+    def provider
+      "GoogleTasks"
     end
 
     class << self

--- a/lib/instapaper/article.rb
+++ b/lib/instapaper/article.rb
@@ -56,10 +56,6 @@ module Instapaper
     end
     memo_wise :read_time
 
-    def sync_id
-      id
-    end
-
     private
 
     def image_time(image_count)

--- a/lib/note_parser.rb
+++ b/lib/note_parser.rb
@@ -7,6 +7,16 @@ module NoteParser
   def parsed_notes(notes:, keys: [])
     return {} if notes.nil?
 
+    # TODO: remove these after we've migrated all the notes
+    # Strips out the old sync_id from the notes
+    sync_id_matcher = /(?:\bsync_id:\s.+)(\R|\z)/
+    match_data = sync_id_matcher.match(notes)
+    notes = notes.split(match_data[0]).join unless match_data.nil?
+    # Also remove the url
+    sync_url_matcher = /(?:\burl:\s.+)(\R|\z)/
+    match_data = sync_url_matcher.match(notes)
+    notes = notes.split(match_data[0]).join unless match_data.nil?
+
     values = {}
     keys.each do |key|
       key_value_matcher = /(?:#{key}:\s(?<value>.+))(\R|\z)/

--- a/lib/note_parser.rb
+++ b/lib/note_parser.rb
@@ -5,7 +5,7 @@ module NoteParser
   # which currently is all of them?
   # parsed_notes expects key value pairs of the form "key: value" on its own line
   def parsed_notes(notes:, keys: [])
-    return if notes.nil?
+    return {} if notes.nil?
 
     values = {}
     keys.each do |key|

--- a/lib/reminders/reminder.rb
+++ b/lib/reminders/reminder.rb
@@ -58,7 +58,7 @@ module Reminders
     memo_wise :original_reminder
 
     def external_sync_notes
-      notes_with_values(notes, sync_id: id)
+      notes_with_values(notes, reminders_id: id)
     end
 
     def friendly_title

--- a/spec/fixtures/asana_task.json
+++ b/spec/fixtures/asana_task.json
@@ -1,1 +1,34 @@
-{ "gid": "1203526342802924", "assignee": null, "completed": false, "completed_at": null, "due_at": "2022-12-14T02:00:00.000Z", "due_on": "2022-12-13", "hearted": false, "memberships": [{ "project": { "gid": "1203152506994879", "name": "Pets" }, "section": { "gid": "1203152506994884", "name": "Bucky" } }], "modified_at": "2022-12-14T07:32:35.605Z", "name": "Find dog training", "notes": "https://www.smartypup.com/pupdog-1-page\n\nhttps://www.dogclubsf.com/dog-recall-training\n\nhttps://www.dogclubsf.com/dog-leash-training\n\nsync_id: jU466dYHf2o\n", "num_subtasks": 0, "permalink_url": "https://app.asana.com/0/1203152506994879/1203526342802924", "projects": [{ "gid": "1203152506994879", "resource_type": "project" }], "start_at": null, "start_on": null }
+{
+  "gid": "1203526342802924",
+  "assignee": null,
+  "completed": false,
+  "completed_at": null,
+  "due_at": "2022-12-14T02:00:00.000Z",
+  "due_on": "2022-12-13",
+  "hearted": false,
+  "memberships": [
+    {
+      "project": {
+        "gid": "1203152506994879",
+        "name": "Pets"
+      },
+      "section": {
+        "gid": "1203152506994884",
+        "name": "Bucky"
+      }
+    }
+  ],
+  "modified_at": "2022-12-14T07:32:35.605Z",
+  "name": "Find dog training",
+  "notes": "https://www.smartypup.com/pupdog-1-page\n\nhttps://www.dogclubsf.com/dog-recall-training\n\nhttps://www.dogclubsf.com/dog-leash-training\n\nomnifocus_id: jU466dYHf2o\n",
+  "num_subtasks": 0,
+  "permalink_url": "https://app.asana.com/0/1203152506994879/1203526342802924",
+  "projects": [
+    {
+      "gid": "1203152506994879",
+      "resource_type": "project"
+    }
+  ],
+  "start_at": null,
+  "start_on": null
+}

--- a/spec/lib/asana/service_spec.rb
+++ b/spec/lib/asana/service_spec.rb
@@ -2,10 +2,8 @@
 
 require "spec_helper"
 
-RSpec.describe "Asana::Service" do
+RSpec.describe "Asana::Service", :full_options do
   let(:service) { Asana::Service.new(options:) }
-  let(:options) { { logger:, tags: ["Asana"] } }
-  let(:logger)  { double(StructuredLogger) }
   let(:last_sync) { Time.now - service.send(:min_sync_interval) }
   let(:httparty_success_mock) { OpenStruct.new(success?: true, body: { data: { task: external_task.to_json } }.to_json) }
 

--- a/spec/lib/asana/task_spec.rb
+++ b/spec/lib/asana/task_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Asana::Task", :full_options do
 
   describe "new" do
     it "parses out the omnifocus_id from notes" do
-      expect(asana_task.sync_id("Omnifocus")).to eq("jU466dYHf2o")
+      expect(asana_task.omnifocus_id).to eq("jU466dYHf2o")
     end
   end
 end

--- a/spec/lib/asana/task_spec.rb
+++ b/spec/lib/asana/task_spec.rb
@@ -2,14 +2,17 @@
 
 require "spec_helper"
 
-RSpec.describe "Asana::Task" do
+RSpec.describe "Asana::Task", :full_options do
   let(:asana_task) { Asana::Task.new(asana_task: asana_task_json, options:) }
   let(:asana_task_json) { JSON.parse(File.read(File.expand_path(File.join(__dir__, "..", "..", "fixtures", "asana_task.json")))) }
-  let(:options) { { tags: [] } }
+
+  it_behaves_like "sync_item" do
+    let(:item) { asana_task }
+  end
 
   describe "new" do
-    it "parses out the sync_id from notes" do
-      expect(asana_task.sync_id).to eq("jU466dYHf2o")
+    it "parses out the omnifocus_id from notes" do
+      expect(asana_task.sync_id("Omnifocus")).to eq("jU466dYHf2o")
     end
   end
 end

--- a/spec/lib/github/issue_spec.rb
+++ b/spec/lib/github/issue_spec.rb
@@ -2,10 +2,9 @@
 
 require "spec_helper"
 
-RSpec.describe "Github::Issue" do
+RSpec.describe "Github::Issue", :full_options do
   let(:service) { Github::Service.new }
   let(:issue) { Github::Issue.new(github_issue: properties, options:) }
-  let(:options) { { tags: [] } }
   let(:id) { Faker::Number.number(digits: 10) }
   let(:number) { Faker::Number.number(digits: 3) }
   let(:title) { Faker::Lorem.sentence }
@@ -27,6 +26,10 @@ RSpec.describe "Github::Issue" do
       "state" => status,
       "labels" => labels
     }.compact
+  end
+
+  it_behaves_like "sync_item" do
+    let(:item) { issue }
   end
 
   it "is marked open" do

--- a/spec/lib/github/service_spec.rb
+++ b/spec/lib/github/service_spec.rb
@@ -2,10 +2,8 @@
 
 require "spec_helper"
 
-RSpec.describe "Github::Service" do
+RSpec.describe "Github::Service", :full_options do
   let(:service) { Github::Service.new(options:) }
-  let(:options) { { logger: } }
-  let(:logger)  { double(StructuredLogger) }
   let(:last_sync) { Time.now - service.send(:min_sync_interval) }
   let(:httparty_success_mock) { OpenStruct.new(success?: true, body: { data: { task: external_task.to_json } }.to_json) }
 
@@ -16,7 +14,7 @@ RSpec.describe "Github::Service" do
 
   describe "#sync_to_primary" do
     context "with omnifocus" do
-      let(:primary_service) { Omnifocus::Service.new(options: {}) }
+      let(:primary_service) { Omnifocus::Service.new(options:) }
 
       it "responds to #sync_to_primary" do
         expect(service).to be_respond_to(:sync_to_primary)

--- a/spec/lib/google_tasks/service_spec.rb
+++ b/spec/lib/google_tasks/service_spec.rb
@@ -2,11 +2,9 @@
 
 require "spec_helper"
 
-RSpec.describe "GoogleTasks::Service" do
+RSpec.describe "GoogleTasks::Service", :full_options do
   let(:service)   { GoogleTasks::Service.new(options:) }
   let(:tasklist)  { "Test" }
-  let(:options)   { { logger: } }
-  let(:logger)    { double(StructuredLogger) }
   let(:last_sync) { Time.now - service.send(:min_sync_interval) }
   let(:httparty_success_mock) { OpenStruct.new(success?: true, body: { data: { task: external_task.to_json } }.to_json) }
 

--- a/spec/lib/google_tasks/task_spec.rb
+++ b/spec/lib/google_tasks/task_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe GoogleTasks::Task, :full_options do
+  let(:google_task) { GoogleTasks::Task.new(google_task: google_task_json, options:) }
+  let(:google_task_json) do
+    {
+      "id" => id,
+      "title" => title,
+      "self_link" => url,
+      "notes" => notes
+    }
+  end
+  let(:id) { Faker::Number.number(digits: 10) }
+  let(:title) { Faker::Lorem.sentence }
+  let(:url) { Faker::Internet.url }
+  let(:notes) { "notes\n\nomnifocus_id: jU466dYHf2o" }
+
+  it_behaves_like "sync_item" do
+    let(:item) { google_task }
+  end
+
+  describe "new" do
+    it "parses out the omnifocus_id from notes" do
+      expect(google_task.sync_id("Omnifocus")).to eq("jU466dYHf2o")
+    end
+  end
+end

--- a/spec/lib/google_tasks/task_spec.rb
+++ b/spec/lib/google_tasks/task_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe GoogleTasks::Task, :full_options do
 
   describe "new" do
     it "parses out the omnifocus_id from notes" do
-      expect(google_task.sync_id("Omnifocus")).to eq("jU466dYHf2o")
+      expect(google_task.omnifocus_id).to eq("jU466dYHf2o")
     end
   end
 end

--- a/spec/lib/instapaper/article_spec.rb
+++ b/spec/lib/instapaper/article_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe "Instapaper::Article" do
+RSpec.describe Instapaper::Article, :full_options do
   let(:title) { Faker::Lorem.sentence }
   let(:folder) { %w[unread archive].sample }
   let(:article_props) do
@@ -16,7 +16,6 @@ RSpec.describe "Instapaper::Article" do
       "updated_at" => Chronic.parse("1 week ago")
     }
   end
-  let(:options) { { tags: [] } }
   let(:article) { Instapaper::Article.new(instapaper_article: article_props, options:) }
 
   describe "#completed?" do

--- a/spec/lib/instapaper/service_spec.rb
+++ b/spec/lib/instapaper/service_spec.rb
@@ -3,10 +3,8 @@
 require "spec_helper"
 require "oauth/request_proxy/mock_request"
 
-RSpec.describe "Instapaper::Service" do
+RSpec.describe "Instapaper::Service", :full_options do
   let(:service) { Instapaper::Service.new(options:) }
-  let(:options) { { logger: } }
-  let(:logger)  { double(StructuredLogger) }
   let(:last_sync) { Time.now - service.send(:min_sync_interval) }
   let(:httparty_success_mock) { OpenStruct.new(success?: true, body: { data: { task: external_task.to_json } }.to_json) }
 
@@ -20,7 +18,7 @@ RSpec.describe "Instapaper::Service" do
 
   describe "#sync_to_primary" do
     context "with omnifocus" do
-      let(:primary_service) { Omnifocus::Service.new(options: {}) }
+      let(:primary_service) { Omnifocus::Service.new(options:) }
 
       it "responds to #sync_to_primary" do
         expect(service).to be_respond_to(:sync_to_primary)

--- a/spec/lib/note_parser_spec.rb
+++ b/spec/lib/note_parser_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "NoteParser" do
   let(:previous_notes) { "notes" }
 
   describe "#parsed_notes" do
-    let(:notes) { "#{previous_notes}\n\nsync_id: #{id}\nurl: #{url}" }
+    let(:notes) { "#{previous_notes}\n\nsync_id: #{id}\nurl: #{url}\n" }
 
     it "returns a Hash" do
       expect(note_parser_class.parsed_notes(keys: %w[sync_id url], notes:)).to be_a(Hash)
@@ -43,10 +43,17 @@ RSpec.describe "NoteParser" do
       expect(parsed_data["notes"]).to eq(previous_notes)
     end
 
-    it "works when there aren't any notes" do
+    it "works when there aren't any notes or ids" do
       parsed_data = note_parser_class.parsed_notes(keys: %w[url sync_id], notes: "")
       expect(parsed_data["sync_id"]).to be_nil
       expect(parsed_data["url"]).to be_nil
+      expect(parsed_data["notes"]).to eq("")
+    end
+
+    it "works when there aren't any notes" do
+      parsed_data = note_parser_class.parsed_notes(keys: %w[url sync_id], notes: "sync_id: #{id}\nurl: #{url}\n")
+      expect(parsed_data["sync_id"]).to eq(id.to_s)
+      expect(parsed_data["url"]).to eq(url)
       expect(parsed_data["notes"]).to eq("")
     end
 

--- a/spec/lib/note_parser_spec.rb
+++ b/spec/lib/note_parser_spec.rb
@@ -9,58 +9,58 @@ RSpec.describe "NoteParser" do
   let(:previous_notes) { "notes" }
 
   describe "#parsed_notes" do
-    let(:notes) { "#{previous_notes}\n\nsync_id: #{id}\nurl: #{url}\n" }
+    let(:notes) { "#{previous_notes}\n\nomnifocus_id: #{id}\nomnifocus_url: #{url}\n" }
 
     it "returns a Hash" do
-      expect(note_parser_class.parsed_notes(keys: %w[sync_id url], notes:)).to be_a(Hash)
+      expect(note_parser_class.parsed_notes(keys: %w[omnifocus_id omnifocus_url], notes:)).to be_a(Hash)
     end
 
     it "parses out the values for the given list of keys" do
-      parsed_data = note_parser_class.parsed_notes(keys: %w[sync_id url], notes:)
-      expect(parsed_data["sync_id"]).to eq(id.to_s)
-      expect(parsed_data["url"]).to eq(url)
+      parsed_data = note_parser_class.parsed_notes(keys: %w[omnifocus_id omnifocus_url], notes:)
+      expect(parsed_data["omnifocus_id"]).to eq(id.to_s)
+      expect(parsed_data["omnifocus_url"]).to eq(url)
       expect(parsed_data["notes"]).to eq(previous_notes)
     end
 
     it "works when there's no newline at the end of the notes" do
-      parsed_data = note_parser_class.parsed_notes(keys: %w[sync_id url], notes: notes.strip)
-      expect(parsed_data["sync_id"]).to eq(id.to_s)
-      expect(parsed_data["url"]).to eq(url)
+      parsed_data = note_parser_class.parsed_notes(keys: %w[omnifocus_id omnifocus_url], notes: notes.strip)
+      expect(parsed_data["omnifocus_id"]).to eq(id.to_s)
+      expect(parsed_data["omnifocus_url"]).to eq(url)
       expect(parsed_data["notes"]).to eq(previous_notes)
     end
 
     it "works when the keys are processed in a different order" do
-      parsed_data = note_parser_class.parsed_notes(keys: %w[url sync_id], notes:)
-      expect(parsed_data["sync_id"]).to eq(id.to_s)
-      expect(parsed_data["url"]).to eq(url)
+      parsed_data = note_parser_class.parsed_notes(keys: %w[omnifocus_url omnifocus_id], notes:)
+      expect(parsed_data["omnifocus_id"]).to eq(id.to_s)
+      expect(parsed_data["omnifocus_url"]).to eq(url)
       expect(parsed_data["notes"]).to eq(previous_notes)
     end
 
     it "works when there aren't extra newlines" do
-      parsed_data = note_parser_class.parsed_notes(keys: %w[url sync_id], notes: notes.squish)
-      expect(parsed_data["sync_id"]).to eq(id.to_s)
-      expect(parsed_data["url"]).to eq(url)
+      parsed_data = note_parser_class.parsed_notes(keys: %w[omnifocus_url omnifocus_id], notes: notes.squish)
+      expect(parsed_data["omnifocus_id"]).to eq(id.to_s)
+      expect(parsed_data["omnifocus_url"]).to eq(url)
       expect(parsed_data["notes"]).to eq(previous_notes)
     end
 
     it "works when there aren't any notes or ids" do
-      parsed_data = note_parser_class.parsed_notes(keys: %w[url sync_id], notes: "")
-      expect(parsed_data["sync_id"]).to be_nil
-      expect(parsed_data["url"]).to be_nil
+      parsed_data = note_parser_class.parsed_notes(keys: %w[omnifocus_url omnifocus_id], notes: "")
+      expect(parsed_data["omnifocus_id"]).to be_nil
+      expect(parsed_data["omnifocus_url"]).to be_nil
       expect(parsed_data["notes"]).to eq("")
     end
 
     it "works when there aren't any notes" do
-      parsed_data = note_parser_class.parsed_notes(keys: %w[url sync_id], notes: "sync_id: #{id}\nurl: #{url}\n")
-      expect(parsed_data["sync_id"]).to eq(id.to_s)
-      expect(parsed_data["url"]).to eq(url)
+      parsed_data = note_parser_class.parsed_notes(keys: %w[omnifocus_url omnifocus_id], notes: "omnifocus_id: #{id}\nomnifocus_url: #{url}\n")
+      expect(parsed_data["omnifocus_id"]).to eq(id.to_s)
+      expect(parsed_data["omnifocus_url"]).to eq(url)
       expect(parsed_data["notes"]).to eq("")
     end
 
     it "returns notes when there aren't any keys" do
       parsed_data = note_parser_class.parsed_notes(notes:)
-      expect(parsed_data["sync_id"]).to be_nil
-      expect(parsed_data["url"]).to be_nil
+      expect(parsed_data["omnifocus_id"]).to be_nil
+      expect(parsed_data["omnifocus_url"]).to be_nil
       expect(parsed_data["notes"]).to eq(notes.strip)
     end
   end
@@ -69,14 +69,14 @@ RSpec.describe "NoteParser" do
     let(:notes) { "notes" }
 
     it "adds the values to the notes" do
-      expect(note_parser_class.notes_with_values(notes, { sync_id: id, url: })).to eq("notes\n\nsync_id: #{id}\nurl: #{url}")
+      expect(note_parser_class.notes_with_values(notes, { omnifocus_id: id, omnifocus_url: url })).to eq("notes\n\nomnifocus_id: #{id}\nomnifocus_url: #{url}")
     end
 
     context "when notes are blank" do
       let(:notes) { "" }
 
       it "adds the values to the notes and strips whitespace" do
-        expect(note_parser_class.notes_with_values(notes, { sync_id: id, url: })).to eq("sync_id: #{id}\nurl: #{url}")
+        expect(note_parser_class.notes_with_values(notes, { omnifocus_id: id, omnifocus_url: url })).to eq("omnifocus_id: #{id}\nomnifocus_url: #{url}")
       end
     end
   end

--- a/spec/lib/omnifocus/service_spec.rb
+++ b/spec/lib/omnifocus/service_spec.rb
@@ -2,10 +2,8 @@
 
 require "spec_helper"
 
-RSpec.describe "Omnifocus::Service" do
+RSpec.describe "Omnifocus::Service", :full_options do
   let(:service) { Omnifocus::Service.new(options:) }
-  let(:options) { { logger:, tags: [] } }
-  let(:logger)  { double(StructuredLogger) }
   let(:last_sync) { Time.now - service.send(:min_sync_interval) }
 
   before do
@@ -14,9 +12,9 @@ RSpec.describe "Omnifocus::Service" do
   end
 
   describe "#items_to_sync" do
-    subject { service.items_to_sync(tags:, inbox:) }
+    subject { service.items_to_sync(tags: sync_tags, inbox:) }
 
-    let(:tags) { nil }
+    let(:sync_tags) { nil }
     let(:inbox) { false }
 
     it "returns an empty array", :no_ci do
@@ -24,7 +22,7 @@ RSpec.describe "Omnifocus::Service" do
     end
 
     context "with tags" do
-      let(:tags) { ["TaskBridge"] }
+      let(:sync_tags) { ["TaskBridge"] }
 
       it "returns tasks with a matching tag", :no_ci do
         expect(subject).not_to be_empty

--- a/spec/lib/omnifocus/task_spec.rb
+++ b/spec/lib/omnifocus/task_spec.rb
@@ -2,16 +2,14 @@
 
 require "spec_helper"
 
-RSpec.describe "Omnifocus::Task" do
+RSpec.describe "Omnifocus::Task", :full_options do
   let(:service) { Omnifocus::Service.new }
   let(:task) { Omnifocus::Task.new(omnifocus_task: properties, options:) }
-  let(:options) { { tags: } }
   let(:id) { SecureRandom.alphanumeric(11) }
   let(:name) { Faker::Lorem.sentence }
   let(:notes) { "notes" }
   let(:completed) { [true, false].sample }
   let(:containing_project) { "Folder:Project" }
-  let(:tags) { [] }
   let(:tasks) { [] }
   let(:properties) do
     OpenStruct.new({
@@ -23,6 +21,10 @@ RSpec.describe "Omnifocus::Task" do
       tags: tags.map { |tag| OpenStruct.new({ name: tag }) },
       tasks:
     }.compact)
+  end
+
+  it_behaves_like "sync_item" do
+    let(:item) { task }
   end
 
   context "with time-related tags" do

--- a/spec/lib/reclaim/task_spec.rb
+++ b/spec/lib/reclaim/task_spec.rb
@@ -2,10 +2,9 @@
 
 require "spec_helper"
 
-RSpec.describe "Reclaim::Task" do
+RSpec.describe "Reclaim::Task", :full_options do
   let(:service) { Reclaim::Service.new }
   let(:task) { Reclaim::Task.new(reclaim_task: properties, options:) }
-  let(:options) { { tags: [], work_tags: "", personal_tags: "" } }
   let(:id) { Faker::Number.number(digits: 7) }
   let(:title) { Faker::Lorem.sentence }
   let(:notes) { "notes" }
@@ -21,6 +20,10 @@ RSpec.describe "Reclaim::Task" do
       "notes" => notes,
       "eventCategory" => event_category
     }.compact
+  end
+
+  it_behaves_like "sync_item" do
+    let(:item) { task }
   end
 
   it "parses the due_date" do

--- a/spec/lib/reminders/reminder_spec.rb
+++ b/spec/lib/reminders/reminder_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Reminders::Reminder", :full_options do
 
   describe "new" do
     it "parses out the omnifocus_id from notes" do
-      expect(reminder.sync_id("Omnifocus")).to eq("jU466dYHf2o")
+      expect(reminder.omnifocus_id).to eq("jU466dYHf2o")
     end
   end
 end

--- a/spec/lib/reminders/reminder_spec.rb
+++ b/spec/lib/reminders/reminder_spec.rb
@@ -2,15 +2,14 @@
 
 require "spec_helper"
 
-RSpec.describe "Reminders::Reminder" do
+RSpec.describe "Reminders::Reminder", :full_options do
   let(:service) { Reminders::Service.new }
   let(:reminder) { Reminders::Reminder.new(reminder: properties, options:) }
-  let(:options) { { tags: [] } }
   let(:id) { "x-apple-reminder://#{SecureRandom.uuid.upcase}" }
   let(:name) { Faker::Lorem.sentence }
   let(:completed) { [true, false].sample }
   let(:containing_list) { SecureRandom.uuid.upcase }
-  let(:body) { "notes\n\nsync_id: jU466dYHf2o" }
+  let(:body) { "notes\n\nomnifocus_id: jU466dYHf2o" }
   let(:properties) do
     OpenStruct.new({
       id:,
@@ -21,9 +20,13 @@ RSpec.describe "Reminders::Reminder" do
     }.compact)
   end
 
+  it_behaves_like "sync_item" do
+    let(:item) { reminder }
+  end
+
   describe "new" do
-    it "parses out the sync_id from notes" do
-      expect(reminder.sync_id).to eq("jU466dYHf2o")
+    it "parses out the omnifocus_id from notes" do
+      expect(reminder.sync_id("Omnifocus")).to eq("jU466dYHf2o")
     end
   end
 end

--- a/spec/lib/reminders/service_spec.rb
+++ b/spec/lib/reminders/service_spec.rb
@@ -2,11 +2,9 @@
 
 require "spec_helper"
 
-RSpec.describe "Reminders::Service" do
+RSpec.describe "Reminders::Service", :full_options do
   let(:service) { Reminders::Service.new(options:) }
-  let(:options) { { logger:, reminders_mapping:, tags: } }
-  let(:logger)  { double(StructuredLogger) }
-  let(:tags)    { [] }
+  let(:options) { full_options.merge({ reminders_mapping: }) }
   let(:reminders_mapping) { "" }
   let(:last_sync) { Time.now - service.send(:min_sync_interval) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@
 
 require "faker"
 require_relative "../lib/task_bridge"
+Dir["./spec/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/support/shared_contexts/options.rb
+++ b/spec/support/shared_contexts/options.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "full_options", full_options: true do
+  let(:options) { full_options }
+  let(:full_options) do
+    {
+      tags:,
+      services: service_names,
+      primary: primary_service_name,
+      personal_tags:,
+      work_tags:,
+      logger:
+    }
+  end
+  let(:tags) { [] }
+  let(:service_names) { %w[Asana Reminders Github GoogleTasks Reclaim Instapaper] }
+  let(:primary_service_name) { "Omnifocus" }
+  let(:logger) { double(StructuredLogger) }
+  let(:personal_tags) { "Personal" }
+  let(:work_tags) { "" }
+end

--- a/spec/support/shared_examples/sync_item_shared_examples.rb
+++ b/spec/support/shared_examples/sync_item_shared_examples.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "sync_item" do
+  context "when creating a new item" do
+    let(:attributes) { item.send(:standard_attribute_map).merge(item.attribute_map).compact }
+
+    it "creates accessors for item attributes" do
+      attributes.each_key do |attribute_key|
+        expect(item).to respond_to(attribute_key.to_sym)
+      end
+    end
+
+    it "creates accessors for notes attributes" do
+      item.send(:all_services, remove_current: true).each do |service|
+        expect(item).to respond_to("#{service.underscore}_id".to_sym)
+        expect(item).to respond_to("#{service.underscore}_url".to_sym)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This should allow a single task to sync with multiple services without using the same id for different services. It will hopefully prevent some cases of circular syncing. 

Fixes https://github.com/viamin/task_bridge/issues/122