### PR TITLE
Remove duplicate ID and URL entries from sync notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /pkg/
 /spec/reports/
 /spec/examples.txt
+/temp/
 /test/tmp/
 /test/version_tmp/
 /tmp/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "ruby.rubocop.suppressRubocopWarnings": true,
+  "ruby.rubocop.onSave": false
+}

--- a/lib/note_parser.rb
+++ b/lib/note_parser.rb
@@ -15,7 +15,7 @@ module NoteParser
         values[key] = nil
       else
         values[key] = match_data[:value].strip
-        notes.gsub!(match_data[0].strip, "")
+        notes = notes.gsub(match_data[0].strip, "")
       end
     end
     values["notes"] = notes.strip

--- a/lib/note_parser.rb
+++ b/lib/note_parser.rb
@@ -7,16 +7,6 @@ module NoteParser
   def parsed_notes(notes:, keys: [])
     return {} if notes.nil?
 
-    # TODO: remove these after we've migrated all the notes
-    # Strips out the old sync_id from the notes
-    sync_id_matcher = /(?:\bsync_id:\s.+)(\R|\z)/
-    match_data = sync_id_matcher.match(notes)
-    notes = notes.split(match_data[0]).join unless match_data.nil?
-    # Also remove the url
-    sync_url_matcher = /(?:\burl:\s.+)(\R|\z)/
-    match_data = sync_url_matcher.match(notes)
-    notes = notes.split(match_data[0]).join unless match_data.nil?
-
     values = {}
     keys.each do |key|
       key_value_matcher = /(?:#{key}:\s(?<value>.+))(\R|\z)/
@@ -25,7 +15,7 @@ module NoteParser
         values[key] = nil
       else
         values[key] = match_data[:value].strip
-        notes = notes.split(match_data[0]).join
+        notes.gsub!(match_data[0].strip, "")
       end
     end
     values["notes"] = notes.strip

--- a/spec/lib/note_parser_spec.rb
+++ b/spec/lib/note_parser_spec.rb
@@ -63,6 +63,15 @@ RSpec.describe "NoteParser" do
       expect(parsed_data["omnifocus_url"]).to be_nil
       expect(parsed_data["notes"]).to eq(notes.strip)
     end
+
+    context "with duplicate keys" do
+      let(:notes) { "#{previous_notes}\nasana_url: https://app.asana.com/0/1205790342215875/1205790342215879\n\nasana_id: 1205790342215879\nasana_url: https://app.asana.com/0/1205790342215875/1205790342215879" }
+
+      it "removes the duplicates" do
+        parsed_data = note_parser_class.parsed_notes(keys: %w[asana_url asana_id], notes:)
+        expect(parsed_data["notes"]).to eq(previous_notes.strip)
+      end
+    end
   end
 
   describe "#notes_with_values" do


### PR DESCRIPTION
When parsing notes, if there was a duplicate key/value pair, originally the first copy would be removed, but the second one would not be, and duplicates would be persisted across syncs. This doesn't fix whatever but originally adds the duplicate entry, but will hopefully remove the duplicates from subsequent syncs. 

Fixes #134 