### PR TITLE
Normalize service initialization: add authorized flag and improve error handling

### DIFF
--- a/lib/asana/service.rb
+++ b/lib/asana/service.rb
@@ -6,9 +6,16 @@ require_relative "../base/service"
 module Asana
   # A service class to talk to the Asana API
   class Service < Base::Service
+    attr_reader :authorized
+
     def initialize(options:)
       super
       @personal_access_token = Chamber.dig!(:asana, :personal_access_token)
+      @authorized = true
+    rescue StandardError => e
+      # If configuration is missing, skip the service
+      puts "Asana initialization failed: #{e.message}" unless options[:quiet]
+      @authorized = false
     end
 
     def item_class

--- a/lib/github/service.rb
+++ b/lib/github/service.rb
@@ -7,14 +7,17 @@ require_relative "../base/service"
 module Github
   # A service class to connect to the Github API
   class Service < Base::Service
-    attr_reader :authentication
+    attr_reader :authentication, :authorized
 
     def initialize(options:)
       super
       @authentication = Authentication.new(options).authenticate!
-    rescue StandardError
+      @authorized = true
+    rescue StandardError => e
       # If authentication fails, skip the service
-      nil
+      puts "Github authentication failed: #{e.message}" unless options[:quiet]
+      @authentication = nil
+      @authorized = false
     end
 
     def item_class

--- a/lib/instapaper/service.rb
+++ b/lib/instapaper/service.rb
@@ -10,14 +10,17 @@ module Instapaper
     UNREAD_ARTICLE_COUNT = 50
     ARCHIVED_ARTICLE_COUNT = 25
 
-    attr_reader :authentication
+    attr_reader :authentication, :authorized
 
     def initialize(options:)
       super
       @authentication = Authentication.new(options).authenticate!
-    rescue StandardError
+      @authorized = true
+    rescue StandardError => e
       # If authentication fails, skip the service
-      nil
+      puts "Instapaper authentication failed: #{e.message}" unless options[:quiet]
+      @authentication = nil
+      @authorized = false
     end
 
     def item_class

--- a/lib/omnifocus/service.rb
+++ b/lib/omnifocus/service.rb
@@ -5,12 +5,18 @@ require_relative "../base/service"
 
 module Omnifocus
   class Service < Base::Service
-    attr_reader :omnifocus_app
+    attr_reader :omnifocus_app, :authorized
 
     def initialize(options: {})
       super
       # Assumes you already have OmniFocus installed
       @omnifocus_app = Appscript.app.by_name(friendly_name).default_document
+      @authorized = true
+    rescue StandardError => e
+      # If OmniFocus app is not available, skip the service
+      puts "OmniFocus initialization failed: #{e.message}" unless options[:quiet]
+      @omnifocus_app = nil
+      @authorized = false
     end
 
     def item_class

--- a/lib/reminders/service.rb
+++ b/lib/reminders/service.rb
@@ -5,12 +5,18 @@ require_relative "../base/service"
 
 module Reminders
   class Service < Base::Service
-    attr_reader :reminders_app
+    attr_reader :reminders_app, :authorized
 
     def initialize(options:)
       super
       # Assumes you already have Reminders installed
       @reminders_app = Appscript.app.by_name(friendly_name)
+      @authorized = true
+    rescue StandardError => e
+      # If Reminders app is not available, skip the service
+      puts "Reminders initialization failed: #{e.message}" unless options[:quiet]
+      @reminders_app = nil
+      @authorized = false
     end
 
     def item_class


### PR DESCRIPTION
- Add attr_reader :authorized to Asana, Github, Instapaper, Omnifocus, Reminders services
- Set @authorized = true on successful initialization and @authorized = false on rescue
- Log initialization/authentication failures with exception messages (respect options[:quiet])
- Ensure service-specific client/auth vars are cleared on failure
- Asana: load personal_access_token from Chamber.dig!(:asana, :personal_access_token)