### PR TITLE
Refactor error handling, logging, and Asana section moves

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
 
 AllCops:

--- a/lib/base/sync_item.rb
+++ b/lib/base/sync_item.rb
@@ -26,7 +26,7 @@ module Base
       note_components.each do |key, value|
         instance_variable_set("@#{key}", value)
         define_singleton_method(key.to_sym) { instance_variable_get("@#{key}") }
-        define_singleton_method("#{key}=".to_sym) { |val| instance_variable_set("@#{key}", val) }
+        define_singleton_method(:"#{key}=") { |val| instance_variable_set("@#{key}", val) }
       end
     end
 
@@ -65,9 +65,9 @@ module Base
     def find_matching_item_in(collection)
       return if collection.blank?
 
-      external_id = "#{collection.first.provider.underscore}_id".to_sym
-      service_id = "#{provider.underscore}_id".to_sym
-      id_match = collection.find { |item| ((item.id && (item.id == try(external_id))) || (item.try(service_id) && (item.try(service_id) == id))) }
+      external_id = :"#{collection.first.provider.underscore}_id"
+      service_id = :"#{provider.underscore}_id"
+      id_match = collection.find { |item| (item.id && (item.id == try(external_id))) || (item.try(service_id) && (item.try(service_id) == id)) }
       return id_match if id_match
 
       collection.find do |item|
@@ -84,7 +84,7 @@ module Base
     end
 
     def external_sync_notes
-      notes_with_values(sync_notes, "#{provider.underscore}_id".to_sym => id, "#{provider.underscore}_url".to_sym => url)
+      notes_with_values(sync_notes, "#{provider.underscore}_id": id, "#{provider.underscore}_url": url)
     end
 
     def sync_notes

--- a/lib/google_tasks/service.rb
+++ b/lib/google_tasks/service.rb
@@ -134,7 +134,10 @@ module GoogleTasks
     # In case a reclaim title is present, match the title
     def friendly_titles_match?(google_task, task)
       matcher = /\A(?<title>#{task.title.strip})\s*(?<addon>.*)\Z/i
-      google_title = matcher.match(google_task.title)&.named_captures&.fetch("title", nil)&.downcase&.strip
+      match_data = matcher.match(google_task.title)
+      named_captures = match_data&.named_captures
+      extracted_title = named_captures&.fetch("title", nil)
+      google_title = extracted_title&.downcase&.strip
       google_title == task.title&.downcase&.strip
     end
   end

--- a/lib/omnifocus/service.rb
+++ b/lib/omnifocus/service.rb
@@ -193,7 +193,8 @@ module Omnifocus
         debug("called with a native Omnifocus task", options[:debug])
         task
       end
-      if target_task.tags.get.map(&:name).map(&:get).include?(tag.name.get)
+      existing_tag_names = target_task.tags.get.map { |existing_tag| existing_tag.name.get }
+      if existing_tag_names.include?(tag.name.get)
         debug("Task (#{target_task.name.get}) already has tag #{tag.name.get}", options[:debug])
       else
         debug("Adding tag #{tag.name.get} to task \"#{target_task.name.get}\"", options[:debug])

--- a/lib/reminders/service.rb
+++ b/lib/reminders/service.rb
@@ -60,11 +60,9 @@ module Reminders
         "Last modified more than #{options[:max_age]} ago - skipping #{external_task.title}"
       elsif external_task.completed? && reminder.incomplete?
         debug("Complete state doesn't match", options[:debug])
-        if options[:pretend]
-          "Would have marked #{reminder.title} complete in Reminders"
-        else
-          reminder.mark_complete unless options[:pretend]
-        end
+        return "Would have marked #{reminder.title} complete in Reminders" if options[:pretend]
+
+        reminder.mark_complete
         reminder_id = reminder.id_.get
         update_sync_data(external_task, reminder_id) if options[:update_ids_for_existing]
         external_task

--- a/lib/structured_logger.rb
+++ b/lib/structured_logger.rb
@@ -3,6 +3,16 @@
 class StructuredLogger
   include Debug
 
+  HEADER_LABELS = {
+    service: "Service",
+    status: "Status",
+    items: "Items",
+    last_success: "Last Success",
+    last_failure: "Last Failure",
+    details: "Details"
+  }.freeze
+  HEADER_LENGTHS = HEADER_LABELS.transform_values(&:length).freeze
+
   attr_reader :options
 
   def initialize(options)
@@ -35,10 +45,116 @@ class StructuredLogger
   end
 
   def print_logs
-    puts format("%-#{@space_needed}s |   Last Attempted   |   Last Successful  | Items Synced", "Service")
-    puts "#{'-' * @space_needed}-|#{'-' * 20}|#{'-' * 20}|#{'-' * 13}"
+    puts format(
+      "%-#{@space_needed}s |   Last Attempted   |   Last Successful  |   Last Failed     | Items Synced | Status",
+      "Service"
+    )
+    puts "#{'-' * @space_needed}-|#{'-' * 20}|#{'-' * 20}|#{'-' * 20}|#{'-' * 13}|#{'-' * 8}"
     @existing_logs.each do |log_hash|
-      puts format("%-#{@space_needed}s | %18s | %18s | %12d", log_hash["service"], log_hash.fetch("last_attempted", ""), log_hash.fetch("last_successful", ""), log_hash.fetch("items_synced", 0)) if options[:services].include?(log_hash["service"].delete(" "))
+      next unless options[:services].include?(log_hash["service"].delete(" "))
+
+      puts format(
+        "%-#{@space_needed}s | %18s | %18s | %18s | %12d | %-6s",
+        log_hash["service"],
+        log_hash.fetch("last_attempted", ""),
+        log_hash.fetch("last_successful", ""),
+        log_hash.fetch("last_failed", ""),
+        log_hash.fetch("items_synced", 0),
+        status_for_log(log_hash)
+      )
+    end
+  end
+
+  def summarize_service_run(service_name:, logs:, default_detail: nil, error: nil)
+    normalized_logs = Array(logs).compact
+    items_synced = normalized_logs.sum { |entry| entry.fetch("items_synced", 0).to_i }
+    last_attempted = pluck_last(normalized_logs, "last_attempted")
+    last_successful = pluck_last(normalized_logs, "last_successful")
+    last_failed = pluck_last(normalized_logs, "last_failed")
+    detail = default_detail || pluck_last(normalized_logs, "detail")
+
+    failed_entry = normalized_logs.reverse.find do |entry|
+      entry["status"].to_s == "failed" || entry["error_message"].present?
+    end
+    status = if failed_entry || error
+      "failed"
+    elsif normalized_logs.any? { |entry| entry["status"].to_s == "success" || entry["last_successful"].present? }
+      "success"
+    elsif normalized_logs.any?
+      "skipped"
+    else
+      "idle"
+    end
+
+    detail = detail.to_s.strip
+    case status
+    when "failed"
+      failure_detail = failure_detail_from(failed_entry) || (error ? "#{error.class}: #{error.message}" : nil)
+      failure_detail = "#{failure_detail} (#{last_failed})" if failure_detail && last_failed
+      detail = [detail, failure_detail].reject(&:blank?).join(" — ")
+      detail = "Failure recorded#{last_failed ? " (#{last_failed})" : ''}" if detail.blank?
+    when "success"
+      detail = items_synced.positive? ? "#{items_synced} items processed" : "No changes detected" if detail.blank?
+    when "skipped"
+      detail = detail.presence || "Sync not required"
+    else
+      detail = detail.presence || "No work performed"
+    end
+
+    {
+      service: service_name,
+      status: status,
+      items_synced: items_synced,
+      last_attempted: last_attempted,
+      last_successful: last_successful,
+      last_failed: last_failed,
+      detail: detail
+    }
+  end
+
+  def print_run_summary(run_summaries)
+    summaries = Array(run_summaries).compact
+    return if summaries.empty?
+
+    service_width = [@space_needed, HEADER_LENGTHS[:service], summaries.map { |s| s[:service].to_s.length }.max].compact.max
+    status_width = [HEADER_LENGTHS[:status], summaries.map { |s| s[:status].to_s.length }.max].compact.max
+    items_width = [HEADER_LENGTHS[:items], summaries.map { |s| s[:items_synced].to_s.length }.max].compact.max
+    success_width = [HEADER_LENGTHS[:last_success], summaries.map { |s| s[:last_successful].to_s.length }.max].compact.max
+    failure_width = [HEADER_LENGTHS[:last_failure], summaries.map { |s| s[:last_failed].to_s.length }.max].compact.max
+    detail_width = [HEADER_LENGTHS[:details], summaries.map { |s| s[:detail].to_s.length }.max].compact.max
+
+    header_format = "%-#{service_width}s | %-#{status_width}s | %#{items_width}s | %-#{success_width}s | %-#{failure_width}s | %-#{detail_width}s"
+    row_format = "%-#{service_width}s | %-#{status_width}s | %#{items_width}d | %-#{success_width}s | %-#{failure_width}s | %-#{detail_width}s"
+
+    puts "Sync summary @ #{options[:sync_started_at]}"
+    puts format(
+      header_format,
+      HEADER_LABELS[:service],
+      HEADER_LABELS[:status],
+      HEADER_LABELS[:items],
+      HEADER_LABELS[:last_success],
+      HEADER_LABELS[:last_failure],
+      HEADER_LABELS[:details]
+    )
+    puts [
+      "-" * service_width,
+      "-" * status_width,
+      "-" * items_width,
+      "-" * success_width,
+      "-" * failure_width,
+      "-" * detail_width
+    ].join("-+-")
+
+    summaries.each do |summary|
+      puts format(
+        row_format,
+        summary[:service],
+        summary[:status],
+        summary[:items_synced],
+        summary[:last_successful].to_s,
+        summary[:last_failed].to_s,
+        summary[:detail].to_s
+      )
     end
   end
 
@@ -58,5 +174,34 @@ class StructuredLogger
     output.sort_by! { |element| element["service"] }
     File.write(@log_file, output.to_json)
     @existing_logs = output
+  end
+
+  private
+
+  def pluck_last(logs, key)
+    logs.filter_map { |entry| entry[key] }.last
+  end
+
+  def status_for_log(log_hash)
+    return log_hash["status"] if log_hash["status"].present?
+
+    if log_hash["error_message"].present?
+      "failed"
+    elsif log_hash["last_successful"].present?
+      "success"
+    elsif log_hash["last_attempted"].present?
+      "skipped"
+    else
+      "unknown"
+    end
+  end
+
+  def failure_detail_from(log_hash)
+    return unless log_hash
+
+    parts = []
+    parts << log_hash["error_class"] if log_hash["error_class"].present?
+    parts << log_hash["error_message"] if log_hash["error_message"].present?
+    parts.presence&.join(": ")
   end
 end

--- a/spec/lib/asana/move_task_to_section_spec.rb
+++ b/spec/lib/asana/move_task_to_section_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Asana::Service do
+  let(:logger) { instance_double(StructuredLogger, sync_data_for: {}) }
+  let(:options) do
+    {
+      logger: logger,
+      services: [],
+      sync_started_at: "2024-01-01 09:00AM",
+      quiet: true,
+      debug: false
+    }
+  end
+
+  subject(:service) { described_class.new(options:) }
+
+  before do
+    allow(logger).to receive(:sync_data_for).and_return({})
+    allow(Chamber).to receive(:dig!).and_call_original
+    allow(Chamber).to receive(:dig!).with(:asana, :personal_access_token).and_return("token")
+  end
+
+  describe "#move_task_to_section" do
+    context "when no section is provided" do
+      it "returns nil without issuing a request" do
+        expect(HTTParty).not_to receive(:post)
+        expect(service.send(:move_task_to_section, nil, "123")).to be_nil
+      end
+    end
+
+    context "when the API request succeeds" do
+      it "returns nil" do
+        response = instance_double(HTTParty::Response, success?: true)
+        allow(HTTParty).to receive(:post).and_return(response)
+
+        expect(service.send(:move_task_to_section, "section_gid", "task_gid")).to be_nil
+      end
+    end
+
+    context "when the API request fails" do
+      it "returns a failure message including the response code" do
+        response = instance_double(HTTParty::Response, success?: false, code: 500, body: "boom")
+        allow(HTTParty).to receive(:post).and_return(response)
+
+        result = service.send(:move_task_to_section, "section_gid", "task_gid")
+
+        expect(result).to eq("Failed to move an Asana task to a section - code 500")
+      end
+    end
+  end
+end

--- a/spec/lib/asana/service_spec.rb
+++ b/spec/lib/asana/service_spec.rb
@@ -79,19 +79,6 @@ RSpec.describe "Asana::Service", :full_options do
     it "raises an error" do
       expect { subject }.to raise_error NoMethodError
     end
-
-    context "with Omnifocus task" do
-      let(:external_task) { Omnifocus::Service.new.items_to_sync(projects: "TaskBridge:Test").first }
-
-      context "with a regular task" do
-      end
-
-      context "with a task with a sub_item" do
-      end
-
-      context "with a task in a section" do
-      end
-    end
   end
 
   describe "#update_item" do

--- a/spec/lib/google_tasks/service_spec.rb
+++ b/spec/lib/google_tasks/service_spec.rb
@@ -73,19 +73,6 @@ RSpec.describe "GoogleTasks::Service", :full_options do
     it "raises an error", :no_ci do
       expect { subject }.to raise_error NoMethodError
     end
-
-    context "with Omnifocus task" do
-      let(:external_task) { Omnifocus::Service.new.items_to_sync(projects: "TaskBridge:Test").first }
-
-      context "with a regular task" do
-      end
-
-      context "with a task with a sub_item" do
-      end
-
-      context "with a task in a section" do
-      end
-    end
   end
 
   describe "#update_item" do

--- a/spec/lib/omnifocus/service_spec.rb
+++ b/spec/lib/omnifocus/service_spec.rb
@@ -37,10 +37,4 @@ RSpec.describe "Omnifocus::Service", :full_options do
       end
     end
   end
-
-  describe "#add_item" do
-  end
-
-  describe "#update_item" do
-  end
 end

--- a/spec/lib/reminders/service_spec.rb
+++ b/spec/lib/reminders/service_spec.rb
@@ -29,10 +29,4 @@ RSpec.describe "Reminders::Service", :full_options do
       end
     end
   end
-
-  describe "#add_item" do
-  end
-
-  describe "#update_item" do
-  end
 end

--- a/spec/lib/reminders/update_item_spec.rb
+++ b/spec/lib/reminders/update_item_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Reminders::Service do
+  let(:logger) { instance_double(StructuredLogger, sync_data_for: {}) }
+  let(:reminders_app) { instance_double("RemindersApp") }
+  let(:base_options) do
+    {
+      logger: logger,
+      services: [],
+      sync_started_at: "2024-01-01 09:00AM",
+      quiet: true,
+      debug: false,
+      reminders_mapping: ""
+    }
+  end
+  let(:options) { base_options }
+
+  subject(:service) { described_class.new(options:) }
+
+  before do
+    allow(logger).to receive(:sync_data_for).and_return({})
+    allow(Appscript).to receive_message_chain(:app, :by_name).and_return(reminders_app)
+  end
+
+  describe "#update_item" do
+    let(:reminder) do
+      instance_double(
+        "ReminderItem",
+        incomplete?: true,
+        title: "Test Reminder"
+      )
+    end
+    let(:external_task) do
+      instance_double(
+        "ExternalTask",
+        completed?: task_completed,
+        updated_at: Time.now,
+        title: "Test Reminder",
+        sync_notes: "notes"
+      )
+    end
+    let(:reminder_id_accessor) { instance_double("ReminderIdAccessor", get: "abc123") }
+    let(:task_completed) { true }
+
+    before do
+      allow(reminder).to receive(:id_).and_return(reminder_id_accessor)
+      allow(external_task).to receive(:update_attributes)
+    end
+
+    context "when running in pretend mode" do
+      let(:options) { base_options.merge(pretend: true) }
+
+      it "returns a message and does not mark the reminder complete" do
+        expect(reminder).not_to receive(:mark_complete)
+
+        result = service.update_item(reminder, external_task)
+
+        expect(result).to eq("Would have marked Test Reminder complete in Reminders")
+      end
+    end
+
+    context "when completing the reminder" do
+      let(:options) { base_options.merge(update_ids_for_existing: true) }
+
+      it "marks the reminder complete and updates sync data" do
+        expect(reminder).to receive(:mark_complete)
+        expect(service).to receive(:update_sync_data).with(external_task, "abc123")
+
+        result = service.update_item(reminder, external_task)
+
+        expect(result).to eq(external_task)
+      end
+    end
+
+    context "when the external task is already completed" do
+      let(:task_completed) { false }
+
+      it "returns nil" do
+        expect(service.update_item(reminder, external_task)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/lib/structured_logger_spec.rb
+++ b/spec/lib/structured_logger_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "stringio"
+
+RSpec.describe StructuredLogger do
+  let(:log_file) { "structured_logger_spec.json" }
+  let(:log_path) { File.expand_path("../../log/#{log_file}", __dir__) }
+  let(:options) do
+    {
+      services: %w[Asana Github],
+      log_file: log_file,
+      sync_started_at: "2024-01-01 09:00AM"
+    }
+  end
+  let(:logger) { described_class.new(options) }
+
+  after do
+    FileUtils.rm_f(log_path)
+  end
+
+  describe "#summarize_service_run" do
+    context "when the service run succeeds" do
+      let(:logs) do
+        [
+          {
+            "service" => "Asana",
+            "last_attempted" => options[:sync_started_at],
+            "last_successful" => options[:sync_started_at],
+            "items_synced" => 3
+          }
+        ]
+      end
+
+      it "returns a success summary with processed items" do
+        summary = logger.summarize_service_run(service_name: "Asana", logs:, default_detail: nil, error: nil)
+        expect(summary[:status]).to eq("success")
+        expect(summary[:items_synced]).to eq(3)
+        expect(summary[:detail]).to include("3 items processed")
+      end
+    end
+
+    context "when the service run fails" do
+      let(:logs) do
+        [
+          {
+            "service" => "Github",
+            "last_attempted" => options[:sync_started_at],
+            "last_failed" => "2024-01-01 09:05AM",
+            "error_class" => "RuntimeError",
+            "error_message" => "boom",
+            "items_synced" => 0,
+            "status" => "failed"
+          }
+        ]
+      end
+
+      it "returns a failure summary with error information" do
+        error = RuntimeError.new("boom")
+        summary = logger.summarize_service_run(service_name: "Github", logs:, default_detail: nil, error:)
+        expect(summary[:status]).to eq("failed")
+        expect(summary[:detail]).to include("RuntimeError: boom")
+        expect(summary[:last_failed]).to eq("2024-01-01 09:05AM")
+      end
+    end
+  end
+
+  describe "#print_run_summary" do
+    it "prints a tabular summary of results" do
+      summaries = [
+        {
+          service: "Asana",
+          status: "success",
+          items_synced: 2,
+          last_successful: "2024-01-01 09:00AM",
+          last_failed: "",
+          detail: "2 items processed"
+        }
+      ]
+
+      output = capture_stdout { logger.print_run_summary(summaries) }
+
+      expect(output).to include("Sync summary @ #{options[:sync_started_at]}")
+      expect(output).to match(/Service\s+\|\s+Status\s+\|\s+Items\s+\|\s+Last Success\s+\|\s+Last Failure\s+\|\s+Details/)
+      expect(output).to match(/Asana\s+\|\s+success\s+\|\s+2\s+\|/)
+      expect(output).to include("2 items processed")
+    end
+  end
+
+  def capture_stdout
+    previous_stdout = $stdout
+    captured = StringIO.new
+    $stdout = captured
+    yield
+    captured.string
+  ensure
+    $stdout = previous_stdout
+  end
+end

--- a/spec/support/shared_examples/sync_item_shared_examples.rb
+++ b/spec/support/shared_examples/sync_item_shared_examples.rb
@@ -12,8 +12,8 @@ RSpec.shared_examples "sync_item" do
 
     it "creates accessors for notes attributes" do
       item.send(:all_services, remove_current: true).each do |service|
-        expect(item).to respond_to("#{service.underscore}_id".to_sym)
-        expect(item).to respond_to("#{service.underscore}_url".to_sym)
+        expect(item).to respond_to(:"#{service.underscore}_id")
+        expect(item).to respond_to(:"#{service.underscore}_url")
       end
     end
   end


### PR DESCRIPTION
- Asana: simplify add_item/update_item flows; extract move_task_to_section, section_identifier_for and failure_message to centralize HTTP error handling and section-move logic.
- TaskBridge: improve orchestration and resilience — aggregate per-service logs, skip unauthorized services, support prune/delete flow, capture exceptions, persist logs and print a run summary.
- StructuredLogger: rewrite summary and printing logic; add header metadata, dynamic column sizing, and helpers (pluck_last, status_for_log, failure_detail_from).
- Base::SyncItem: fix dynamic setter definition and tighten id lookup by using symbol literals; simplify external_sync_notes key building.
- GoogleTasks: clarify title extraction in friendly_titles_match? to avoid chained nil calls.
- Omnifocus: optimize tag presence check by precomputing tag names.
- Reminders: simplify pretend handling in update_item and return early when appropriate.
- Specs: add tests for Asana move_task_to_section, Reminders.update_item, and StructuredLogger; remove/refine outdated contexts and examples.