### PR TITLE
Fix dry-run sync correctness and OmniFocus lookups

### DIFF
--- a/app/models/base/sync_item.rb
+++ b/app/models/base/sync_item.rb
@@ -82,14 +82,14 @@ module Base
       end
     end
 
-    validates :external_id, uniqueness: { scope: :type }
+    validates :external_id, uniqueness: {scope: :type}
 
     def read_original(only_modified_dates: false)
       values_hash = external_attribute_map.each_with_object({}) do |(attribute_key, attribute_value), hash|
         next if only_modified_dates &&
-                !self.class.send(:modified_date_attributes).include?(attribute_key) &&
-                !self.class.send(:identity_attributes).include?(attribute_key) &&
-                !self.class.send(:completion_indicator_attributes).include?(attribute_key)
+          !self.class.send(:modified_date_attributes).include?(attribute_key) &&
+          !self.class.send(:identity_attributes).include?(attribute_key) &&
+          !self.class.send(:completion_indicator_attributes).include?(attribute_key)
 
         value = read_external_attribute(external_data, attribute_value, only_modified_dates:, attribute_key:)
         value = Chronic.parse(value) if value && chronic_attributes.include?(attribute_key)
@@ -256,17 +256,17 @@ module Base
       def read_external_attribute(external_data, attribute, only_modified_dates: false, attribute_key: nil)
         return if attribute.nil?
         return if only_modified_dates && attribute_key &&
-                  !modified_date_attributes.include?(attribute_key) &&
-                  !identity_attributes.include?(attribute_key) &&
-                  !completion_indicator_attributes.include?(attribute_key)
+          !modified_date_attributes.include?(attribute_key) &&
+          !identity_attributes.include?(attribute_key) &&
+          !completion_indicator_attributes.include?(attribute_key)
 
         value = if external_data.is_a? Hash
-          external_data.fetch(attribute, nil)
+          external_data.fetch(attribute) { external_data.fetch(attribute.to_s) { external_data.fetch(attribute.to_sym, nil) } }
         elsif external_data.respond_to?(attribute.to_sym)
           external_data.send(attribute.to_sym)
         end
         value = value.get if value.respond_to?(:get)
-        value == :missing_value ? nil : value
+        (value == :missing_value) ? nil : value
       rescue Appscript::CommandError => e
         # Stale AppleScript references (e.g., OSERROR -1728 "Can't get reference")
         # occur when a task is deleted mid-iteration. Return nil to keep the sync

--- a/app/models/base/sync_item.rb
+++ b/app/models/base/sync_item.rb
@@ -82,14 +82,14 @@ module Base
       end
     end
 
-    validates :external_id, uniqueness: {scope: :type}
+    validates :external_id, uniqueness: { scope: :type }
 
     def read_original(only_modified_dates: false)
       values_hash = external_attribute_map.each_with_object({}) do |(attribute_key, attribute_value), hash|
         next if only_modified_dates &&
-          !self.class.send(:modified_date_attributes).include?(attribute_key) &&
-          !self.class.send(:identity_attributes).include?(attribute_key) &&
-          !self.class.send(:completion_indicator_attributes).include?(attribute_key)
+                !self.class.send(:modified_date_attributes).include?(attribute_key) &&
+                !self.class.send(:identity_attributes).include?(attribute_key) &&
+                !self.class.send(:completion_indicator_attributes).include?(attribute_key)
 
         value = read_external_attribute(external_data, attribute_value, only_modified_dates:, attribute_key:)
         value = Chronic.parse(value) if value && chronic_attributes.include?(attribute_key)
@@ -256,9 +256,9 @@ module Base
       def read_external_attribute(external_data, attribute, only_modified_dates: false, attribute_key: nil)
         return if attribute.nil?
         return if only_modified_dates && attribute_key &&
-          !modified_date_attributes.include?(attribute_key) &&
-          !identity_attributes.include?(attribute_key) &&
-          !completion_indicator_attributes.include?(attribute_key)
+                  !modified_date_attributes.include?(attribute_key) &&
+                  !identity_attributes.include?(attribute_key) &&
+                  !completion_indicator_attributes.include?(attribute_key)
 
         value = if external_data.is_a? Hash
           external_data.fetch(attribute) { external_data.fetch(attribute.to_s) { external_data.fetch(attribute.to_sym, nil) } }
@@ -266,7 +266,7 @@ module Base
           external_data.send(attribute.to_sym)
         end
         value = value.get if value.respond_to?(:get)
-        (value == :missing_value) ? nil : value
+        value == :missing_value ? nil : value
       rescue Appscript::CommandError => e
         # Stale AppleScript references (e.g., OSERROR -1728 "Can't get reference")
         # occur when a task is deleted mid-iteration. Return nil to keep the sync

--- a/app/models/omnifocus/task.rb
+++ b/app/models/omnifocus/task.rb
@@ -83,6 +83,12 @@ module Omnifocus
 
     def read_original(only_modified_dates: false)
       super
+      if only_modified_dates
+        @sub_items = []
+        @sub_item_count = 0
+        return self
+      end
+
       containing_project = read_external_attribute(omnifocus_task, :containing_project, only_modified_dates:)
       @project = if containing_project.respond_to?(:get)
         containing_project.name.get

--- a/app/services/base/service.rb
+++ b/app/services/base/service.rb
@@ -45,6 +45,11 @@ module Base
 
       sync_errors = []
       touched_collection_ids = []
+      if (unavailable_error = service_unavailable_error(primary_service))
+        warn_sync_errors([unavailable_error])
+        return sync_result(0, touched_collection_ids:, errors: [unavailable_error])
+      end
+
       primary_items = primary_service.items_to_sync(tags: [friendly_name])
       service_items ||= items_to_sync(tags: options[:tags])
 
@@ -104,7 +109,16 @@ module Base
       sync_errors = []
       touched_collection_ids = []
       service_items ||= items_to_sync(tags: options[:tags], only_modified_dates: true)
-      existing_primary_items = existing_items(primary_service)
+      if service_items.empty?
+        puts "Synced 0 #{friendly_name} items to #{primary_service.friendly_name}" unless options[:quiet]
+        return sync_result(0, touched_collection_ids:, errors: sync_errors)
+      end
+      if (unavailable_error = service_unavailable_error(primary_service))
+        warn_sync_errors([unavailable_error])
+        return sync_result(0, touched_collection_ids:, errors: [unavailable_error])
+      end
+
+      existing_primary_items = existing_items_for(primary_service, service_items)
       unless options[:quiet]
         progressbar = ProgressBar.create(
           format: "%t: %c/%C |%w>%i| %e ",
@@ -147,6 +161,11 @@ module Base
 
       sync_errors = []
       touched_collection_ids = []
+      if (unavailable_error = service_unavailable_error(primary_service))
+        warn_sync_errors([unavailable_error])
+        return sync_result(0, touched_collection_ids:, errors: [unavailable_error])
+      end
+
       primary_items = primary_service.items_to_sync(tags: [friendly_name])
       service_items ||= items_to_sync(tags: options[:tags])
       unless options[:quiet]
@@ -209,7 +228,13 @@ module Base
     end
 
     def existing_items(service)
-      service.items_to_sync(tags: [friendly_name], inbox: true)
+      service.items_to_sync(tags: [friendly_name], inbox: true, only_modified_dates: true)
+    end
+
+    def existing_items_for(service, service_items)
+      return service.matching_items_for(service_items, tag: friendly_name) if service.respond_to?(:matching_items_for)
+
+      existing_items(service)
     end
 
     def items_to_sync(*, **)
@@ -244,6 +269,12 @@ module Base
       nil
     end
 
+    def service_unavailable_error(service)
+      return unless service.respond_to?(:authorized) && service.authorized == false
+
+      "Failed to sync with #{service.friendly_name}: service is not authorized"
+    end
+
     # find all paired items
     def paired_items(primary_items, service_items)
       paired_items = Set.new
@@ -270,7 +301,7 @@ module Base
 
       existing_collection_ids = collection_items.filter_map(&:sync_collection_id).uniq
       if existing_collection_ids.many?
-        debug("Skipping sync collection persistence because items are already linked to different collections: #{existing_collection_ids.join(', ')}")
+        debug("Skipping sync collection persistence because items are already linked to different collections: #{existing_collection_ids.join(", ")}")
         return
       end
 

--- a/app/services/base/service.rb
+++ b/app/services/base/service.rb
@@ -228,7 +228,7 @@ module Base
     end
 
     def existing_items(service)
-      service.items_to_sync(tags: [friendly_name], inbox: true, only_modified_dates: true)
+      service.items_to_sync(tags: [friendly_name], inbox: true)
     end
 
     def existing_items_for(service, service_items)

--- a/app/services/base/service.rb
+++ b/app/services/base/service.rb
@@ -108,14 +108,14 @@ module Base
 
       sync_errors = []
       touched_collection_ids = []
+      if (unavailable_error = service_unavailable_error(primary_service))
+        warn_sync_errors([unavailable_error])
+        return sync_result(0, touched_collection_ids:, errors: [unavailable_error])
+      end
       service_items ||= items_to_sync(tags: options[:tags], only_modified_dates: true)
       if service_items.empty?
         puts "Synced 0 #{friendly_name} items to #{primary_service.friendly_name}" unless options[:quiet]
         return sync_result(0, touched_collection_ids:, errors: sync_errors)
-      end
-      if (unavailable_error = service_unavailable_error(primary_service))
-        warn_sync_errors([unavailable_error])
-        return sync_result(0, touched_collection_ids:, errors: [unavailable_error])
       end
 
       existing_primary_items = existing_items_for(primary_service, service_items)

--- a/app/services/base/service.rb
+++ b/app/services/base/service.rb
@@ -301,7 +301,7 @@ module Base
 
       existing_collection_ids = collection_items.filter_map(&:sync_collection_id).uniq
       if existing_collection_ids.many?
-        debug("Skipping sync collection persistence because items are already linked to different collections: #{existing_collection_ids.join(", ")}")
+        debug("Skipping sync collection persistence because items are already linked to different collections: #{existing_collection_ids.join(', ')}")
         return
       end
 

--- a/app/services/omnifocus/service.rb
+++ b/app/services/omnifocus/service.rb
@@ -57,23 +57,21 @@ module Omnifocus
     def matching_items_for(service_items, tag:)
       return [] unless authorized
 
-      needs_title_lookup = service_items.any? { |service_item| service_item.try(:omnifocus_id).blank? }
-      task_summaries_by_title = if needs_title_lookup
-        matching_task_summaries(tag).group_by { |task| normalized_title_key(task[:name]) }
-      else
-        {}
-      end
-      service_items
-        .flat_map { |service_item| matching_external_data_for(service_item, task_summaries_by_title:) }
-        .uniq { |external_data| external_id_for(external_data) }
-        .filter_map do |external_data|
-          external_id = external_id_for(external_data)
-          next if external_id.blank?
-
-          task = Task.find_or_initialize_by(external_id:)
-          task.omnifocus_task = external_data
-          task.refresh_from_external!(only_modified_dates: true)
+      task_summaries_by_title = nil
+      matching_external_data = service_items.flat_map do |service_item|
+        matching_external_data_for(service_item, source_provider: tag) do
+          task_summaries_by_title ||= matching_task_summaries(tag).group_by { |task| normalized_title_key(task[:name]) }
         end
+      end
+
+      matching_external_data.uniq { |external_data| external_id_for(external_data) }.filter_map do |external_data|
+        external_id = external_id_for(external_data)
+        next if external_id.blank?
+
+        task = Task.find_or_initialize_by(external_id:)
+        task.omnifocus_task = external_data
+        task.refresh_from_external!(only_modified_dates: true)
+      end
     end
 
     def add_item(external_task, parent_object = nil)
@@ -214,15 +212,16 @@ module Omnifocus
       external_task
     end
 
-    def matching_external_data_for(service_item, task_summaries_by_title:)
+    def matching_external_data_for(service_item, source_provider:)
       omnifocus_id = service_item.try(:omnifocus_id)
       if omnifocus_id.present?
         task = task_by_id(omnifocus_id)
         return [external_data_for(task, only_modified_dates: true)].compact if task
       end
 
-      task_summaries_by_title.fetch(normalized_title_key(service_item.friendly_title), [])
-                             .filter_map { |task_summary| external_data_for_summary(task_summary) }
+      resolved_source_provider = service_item.try(:provider) || service_item.try(:provider_name) || source_provider
+      yield.fetch(normalized_title_key(service_item.friendly_title), [])
+           .filter_map { |task_summary| external_data_for_summary(task_summary, source_provider: resolved_source_provider) }
     end
 
     def normalized_title_key(title)
@@ -236,14 +235,19 @@ module Omnifocus
       nil
     end
 
-    def external_data_for_summary(task_summary)
+    def external_data_for_summary(task_summary, source_provider:)
       external_id = task_summary[:id_]
       return if external_id.blank?
 
       existing_task = Task.find_by(external_id:)
-      return unless existing_task && !existing_task.notes.nil?
+      return unless existing_task && sync_metadata_present?(existing_task, source_provider)
 
       task_summary.merge(note: existing_task.notes)
+    end
+
+    def sync_metadata_present?(task, source_provider)
+      task.read_notes
+      task.try(:"#{source_provider.underscore}_id").present?
     end
 
     def matching_task_summaries(tag)

--- a/app/services/omnifocus/service.rb
+++ b/app/services/omnifocus/service.rb
@@ -58,7 +58,11 @@ module Omnifocus
       return [] unless authorized
 
       needs_title_lookup = service_items.any? { |service_item| service_item.try(:omnifocus_id).blank? }
-      task_summaries_by_title = needs_title_lookup ? matching_task_summaries(tag).group_by { |task| task[:name] } : {}
+      task_summaries_by_title = if needs_title_lookup
+        matching_task_summaries(tag).group_by { |task| normalized_title_key(task[:name]) }
+      else
+        {}
+      end
       service_items
         .flat_map { |service_item| matching_external_data_for(service_item, task_summaries_by_title:) }
         .uniq { |external_data| external_id_for(external_data) }
@@ -126,7 +130,7 @@ module Omnifocus
         # Title match: external_task doesn't have our sync ID, or has a stale one
         # (pointing to a different/deleted OmniFocus task)
         matched_by_title = external_task.try(:omnifocus_id).blank? ||
-          external_task.try(:omnifocus_id) != omnifocus_task.external_id
+                           external_task.try(:omnifocus_id) != omnifocus_task.external_id
         # Only move projects for ID-matched items (reliable link)
         # Title matches are not reliable enough to warrant moving tasks between projects
         if !matched_by_title && external_task.try(:project) && !task_projects_match(external_task, omnifocus_task)
@@ -175,7 +179,7 @@ module Omnifocus
         begin
           tag_ref.get # Verify tag exists
           tag_ref
-        rescue
+        rescue StandardError
           nil # Tag doesn't exist
         end
       end
@@ -206,7 +210,7 @@ module Omnifocus
       return external_task unless only_modified_dates
 
       external_task.properties_.get
-    rescue
+    rescue StandardError
       external_task
     end
 
@@ -217,14 +221,18 @@ module Omnifocus
         return [external_data_for(task, only_modified_dates: true)].compact if task
       end
 
-      task_summaries_by_title.fetch(service_item.friendly_title, [])
-        .filter_map { |task_summary| external_data_for_summary(task_summary) }
+      task_summaries_by_title.fetch(normalized_title_key(service_item.friendly_title), [])
+                             .filter_map { |task_summary| external_data_for_summary(task_summary) }
+    end
+
+    def normalized_title_key(title)
+      title.to_s.strip.downcase
     end
 
     def task_by_id(external_id)
       task = omnifocus_app.flattened_tasks.ID(external_id)
       task.get
-    rescue
+    rescue StandardError
       nil
     end
 
@@ -249,13 +257,13 @@ module Omnifocus
         tag_ref.get
         task_summaries_for_collection(tag_ref.tasks)
       end
-    rescue
+    rescue StandardError
       []
     end
 
     def task_summaries_for_inbox
       @task_summaries_for_inbox ||= task_summaries_for_collection(omnifocus_app.inbox_tasks)
-    rescue
+    rescue StandardError
       []
     end
 
@@ -346,7 +354,7 @@ module Omnifocus
     def folder(folder_name)
       debug("folder_name: #{folder_name}", options[:debug])
       omnifocus_app.flattened_folders[folder_name].get
-    rescue
+    rescue StandardError
       puts "The folder #{folder_name} could not be found in Omnifocus" if options[:verbose]
       nil
     end
@@ -375,7 +383,7 @@ module Omnifocus
       debug("project: #{project.name.get}", options[:debug])
       project.get
       project
-    rescue
+    rescue StandardError
       puts "The project #{project_structure} does not exist in Omnifocus" if options[:verbose]
       nil
     end
@@ -384,7 +392,7 @@ module Omnifocus
     def tag(name)
       tag = omnifocus_app.flattened_tags[name]
       tag.get
-    rescue
+    rescue StandardError
       puts "The tag #{name} does not exist in Omnifocus" if options[:verbose]
       nil
     end
@@ -396,10 +404,10 @@ module Omnifocus
 
     def all_tasks_in_container(container, incomplete_only: false)
       tasks = case container
-      when Array
-        container.map { |subcontainer| subcontainer.tasks.get.flatten.map { |t| all_omnifocus_sub_items(t) }.flatten.compact.uniq(&:id_) }.flatten
-      when Appscript::Reference
-        container.tasks.get.flatten.map { |t| all_omnifocus_sub_items(t) }.flatten.compact.uniq(&:id_)
+              when Array
+                container.map { |subcontainer| subcontainer.tasks.get.flatten.map { |t| all_omnifocus_sub_items(t) }.flatten.compact.uniq(&:id_) }.flatten
+              when Appscript::Reference
+                container.tasks.get.flatten.map { |t| all_omnifocus_sub_items(t) }.flatten.compact.uniq(&:id_)
       end
       return tasks unless incomplete_only
 

--- a/app/services/omnifocus/service.rb
+++ b/app/services/omnifocus/service.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "timeout"
+
 module Omnifocus
   class Service < Base::Service
     include Base::AppleScriptLoader
@@ -9,6 +11,7 @@ module Omnifocus
     def initialize(options: nil)
       super
       ensure_appscript_loaded!
+      warm_omnifocus_applescript!
       # Assumes you already have OmniFocus installed
       @omnifocus_app = Appscript.app.by_name(friendly_name).default_document
       @authorized = true
@@ -37,17 +40,36 @@ module Omnifocus
       omnifocus_tasks = tagged_tasks(tags)
       omnifocus_tasks += inbox_tasks if inbox
       tasks = omnifocus_tasks.filter_map do |external_task|
-        external_id = external_id_for(external_task)
+        external_data = external_data_for(external_task, only_modified_dates:)
+        external_id = external_id_for(external_data)
         next if external_id.blank?
 
         task = Task.find_or_initialize_by(external_id:)
-        task.omnifocus_task = external_task
+        task.omnifocus_task = external_data
         task.refresh_from_external!(only_modified_dates:)
       end
       # remove sub_items from the list to avoid duplicates
       tasks_with_sub_items = tasks.select { |task| task.sub_item_count.positive? }
       sub_item_ids = tasks_with_sub_items.map(&:sub_items).flatten.map(&:external_id)
       tasks.delete_if { |task| sub_item_ids.include?(task.external_id) }
+    end
+
+    def matching_items_for(service_items, tag:)
+      return [] unless authorized
+
+      needs_title_lookup = service_items.any? { |service_item| service_item.try(:omnifocus_id).blank? }
+      task_summaries_by_title = needs_title_lookup ? matching_task_summaries(tag).group_by { |task| task[:name] } : {}
+      service_items
+        .flat_map { |service_item| matching_external_data_for(service_item, task_summaries_by_title:) }
+        .uniq { |external_data| external_id_for(external_data) }
+        .filter_map do |external_data|
+          external_id = external_id_for(external_data)
+          next if external_id.blank?
+
+          task = Task.find_or_initialize_by(external_id:)
+          task.omnifocus_task = external_data
+          task.refresh_from_external!(only_modified_dates: true)
+        end
     end
 
     def add_item(external_task, parent_object = nil)
@@ -104,7 +126,7 @@ module Omnifocus
         # Title match: external_task doesn't have our sync ID, or has a stale one
         # (pointing to a different/deleted OmniFocus task)
         matched_by_title = external_task.try(:omnifocus_id).blank? ||
-                           external_task.try(:omnifocus_id) != omnifocus_task.external_id
+          external_task.try(:omnifocus_id) != omnifocus_task.external_id
         # Only move projects for ID-matched items (reliable link)
         # Title matches are not reliable enough to warrant moving tasks between projects
         if !matched_by_title && external_task.try(:project) && !task_projects_match(external_task, omnifocus_task)
@@ -153,7 +175,7 @@ module Omnifocus
         begin
           tag_ref.get # Verify tag exists
           tag_ref
-        rescue StandardError
+        rescue
           nil # Tag doesn't exist
         end
       end
@@ -166,8 +188,93 @@ module Omnifocus
       15.minutes.to_i
     end
 
+    def warm_omnifocus_applescript!
+      return if Rails.env.test?
+
+      Timeout.timeout(5) do
+        system("osascript", "-e", "tell application \"OmniFocus\" to count documents", out: File::NULL, err: File::NULL)
+      end
+    rescue Timeout::Error, SystemCallError
+      nil
+    end
+
     def external_id_for(external_task)
       Task.read_external_attribute(external_task, Task.external_attribute_map[:external_id])
+    end
+
+    def external_data_for(external_task, only_modified_dates:)
+      return external_task unless only_modified_dates
+
+      external_task.properties_.get
+    rescue
+      external_task
+    end
+
+    def matching_external_data_for(service_item, task_summaries_by_title:)
+      omnifocus_id = service_item.try(:omnifocus_id)
+      if omnifocus_id.present?
+        task = task_by_id(omnifocus_id)
+        return [external_data_for(task, only_modified_dates: true)].compact if task
+      end
+
+      task_summaries_by_title.fetch(service_item.friendly_title, [])
+        .filter_map { |task_summary| external_data_for_summary(task_summary) }
+    end
+
+    def task_by_id(external_id)
+      task = omnifocus_app.flattened_tasks.ID(external_id)
+      task.get
+    rescue
+      nil
+    end
+
+    def external_data_for_summary(task_summary)
+      external_id = task_summary[:id_]
+      return if external_id.blank?
+
+      existing_task = Task.find_by(external_id:)
+      return unless existing_task && !existing_task.notes.nil?
+
+      task_summary.merge(note: existing_task.notes)
+    end
+
+    def matching_task_summaries(tag)
+      (task_summaries_for_tag(tag) + task_summaries_for_inbox).uniq { |task_summary| task_summary[:id_] }
+    end
+
+    def task_summaries_for_tag(tag)
+      @task_summaries_by_tag ||= {}
+      @task_summaries_by_tag[tag] ||= begin
+        tag_ref = omnifocus_app.flattened_tags[tag]
+        tag_ref.get
+        task_summaries_for_collection(tag_ref.tasks)
+      end
+    rescue
+      []
+    end
+
+    def task_summaries_for_inbox
+      @task_summaries_for_inbox ||= task_summaries_for_collection(omnifocus_app.inbox_tasks)
+    rescue
+      []
+    end
+
+    def task_summaries_for_collection(task_collection)
+      ids = Array(task_collection.id_.get)
+      names = Array(task_collection.name.get)
+      completed_values = Array(task_collection.completed.get)
+      modification_dates = Array(task_collection.modification_date.get)
+
+      names.each_with_index.map do |name, index|
+        {
+          id_: ids[index],
+          name:,
+          completed: completed_values[index],
+          modification_date: modification_dates[index],
+          completion_date: nil,
+          note: nil
+        }
+      end
     end
 
     # create or update sub_items on a task
@@ -239,7 +346,7 @@ module Omnifocus
     def folder(folder_name)
       debug("folder_name: #{folder_name}", options[:debug])
       omnifocus_app.flattened_folders[folder_name].get
-    rescue StandardError
+    rescue
       puts "The folder #{folder_name} could not be found in Omnifocus" if options[:verbose]
       nil
     end
@@ -268,7 +375,7 @@ module Omnifocus
       debug("project: #{project.name.get}", options[:debug])
       project.get
       project
-    rescue StandardError
+    rescue
       puts "The project #{project_structure} does not exist in Omnifocus" if options[:verbose]
       nil
     end
@@ -277,7 +384,7 @@ module Omnifocus
     def tag(name)
       tag = omnifocus_app.flattened_tags[name]
       tag.get
-    rescue StandardError
+    rescue
       puts "The tag #{name} does not exist in Omnifocus" if options[:verbose]
       nil
     end
@@ -289,10 +396,10 @@ module Omnifocus
 
     def all_tasks_in_container(container, incomplete_only: false)
       tasks = case container
-              when Array
-                container.map { |subcontainer| subcontainer.tasks.get.flatten.map { |t| all_omnifocus_sub_items(t) }.flatten.compact.uniq(&:id_) }.flatten
-              when Appscript::Reference
-                container.tasks.get.flatten.map { |t| all_omnifocus_sub_items(t) }.flatten.compact.uniq(&:id_)
+      when Array
+        container.map { |subcontainer| subcontainer.tasks.get.flatten.map { |t| all_omnifocus_sub_items(t) }.flatten.compact.uniq(&:id_) }.flatten
+      when Appscript::Reference
+        container.tasks.get.flatten.map { |t| all_omnifocus_sub_items(t) }.flatten.compact.uniq(&:id_)
       end
       return tasks unless incomplete_only
 

--- a/lib/tasks/sync.rake
+++ b/lib/tasks/sync.rake
@@ -11,7 +11,7 @@ namespace :task_bridge do
     overrides = options
     o = OptionParser.new
     supported_services = Chamber.dig!(:task_bridge, :all_supported_services)
-    o.banner = "Sync Tasks from one service to another\nSupported services: #{supported_services.join(", ")}\nBy default, tasks found with the tags in --tags will have a work context"
+    o.banner = "Sync Tasks from one service to another\nSupported services: #{supported_services.join(', ')}\nBy default, tasks found with the tags in --tags will have a work context"
     o.on("-p", "--primary [PRIMARY]", "Primary task service") do |value|
       overrides[:primary] = value
       overrides[:primary_service] = "#{value}::Service".safe_constantize
@@ -49,7 +49,7 @@ namespace :task_bridge do
     raise OptionParser::InvalidOption, "--only-from-primary and --only-to-primary are mutually exclusive" if options[:only_from_primary] && options[:only_to_primary]
 
     unsupported_services = options[:services] - supported_services
-    raise "Supported services: #{supported_services.join(", ")}" if unsupported_services.any?
+    raise "Supported services: #{supported_services.join(', ')}" if unsupported_services.any?
 
     if options[:history]
       StructuredLogger.new(log_file: options[:log_file], services: options[:services]).print_logs
@@ -80,7 +80,7 @@ namespace :task_bridge do
       @service_logs = []
       begin
         if service.respond_to?(:authorized) && service.authorized == false
-          @service_logs << {service: service.friendly_name, last_attempted: options[:sync_started_at]}.stringify_keys
+          @service_logs << { service: service.friendly_name, last_attempted: options[:sync_started_at] }.stringify_keys
         elsif options[:delete]
           service.prune if service.respond_to?(:prune)
           @service_logs << {
@@ -124,7 +124,7 @@ namespace :task_bridge do
           @service_logs << service.sync_from_primary(@primary_service) if service.sync_strategies.include?(:from_primary)
           @service_logs << service.sync_to_primary(@primary_service) if service.sync_strategies.include?(:to_primary)
         end
-      rescue => e
+      rescue StandardError => e
         failed_services = true
         @service_logs << {
           service: service.friendly_name,

--- a/lib/tasks/sync.rake
+++ b/lib/tasks/sync.rake
@@ -11,7 +11,7 @@ namespace :task_bridge do
     overrides = options
     o = OptionParser.new
     supported_services = Chamber.dig!(:task_bridge, :all_supported_services)
-    o.banner = "Sync Tasks from one service to another\nSupported services: #{supported_services.join(', ')}\nBy default, tasks found with the tags in --tags will have a work context"
+    o.banner = "Sync Tasks from one service to another\nSupported services: #{supported_services.join(", ")}\nBy default, tasks found with the tags in --tags will have a work context"
     o.on("-p", "--primary [PRIMARY]", "Primary task service") do |value|
       overrides[:primary] = value
       overrides[:primary_service] = "#{value}::Service".safe_constantize
@@ -49,7 +49,7 @@ namespace :task_bridge do
     raise OptionParser::InvalidOption, "--only-from-primary and --only-to-primary are mutually exclusive" if options[:only_from_primary] && options[:only_to_primary]
 
     unsupported_services = options[:services] - supported_services
-    raise "Supported services: #{supported_services.join(', ')}" if unsupported_services.any?
+    raise "Supported services: #{supported_services.join(", ")}" if unsupported_services.any?
 
     if options[:history]
       StructuredLogger.new(log_file: options[:log_file], services: options[:services]).print_logs
@@ -80,7 +80,7 @@ namespace :task_bridge do
       @service_logs = []
       begin
         if service.respond_to?(:authorized) && service.authorized == false
-          @service_logs << { service: service.friendly_name, last_attempted: options[:sync_started_at] }.stringify_keys
+          @service_logs << {service: service.friendly_name, last_attempted: options[:sync_started_at]}.stringify_keys
         elsif options[:delete]
           service.prune if service.respond_to?(:prune)
           @service_logs << {
@@ -124,7 +124,7 @@ namespace :task_bridge do
           @service_logs << service.sync_from_primary(@primary_service) if service.sync_strategies.include?(:from_primary)
           @service_logs << service.sync_to_primary(@primary_service) if service.sync_strategies.include?(:to_primary)
         end
-      rescue StandardError => e
+      rescue => e
         failed_services = true
         @service_logs << {
           service: service.friendly_name,
@@ -137,6 +137,7 @@ namespace :task_bridge do
         }.stringify_keys
         warn "Sync failed for #{service.friendly_name}: #{e.class} #{e.message}" unless options[:quiet]
       end
+      failed_services ||= @service_logs.any? { |log| log["status"] == "failed" }
       options[:logger].save_service_log!(@service_logs)
       SyncServiceState.record_summary!(
         options[:logger].summarize_service_run(service_name: service.friendly_name, logs: @service_logs)

--- a/spec/models/base/service_spec.rb
+++ b/spec/models/base/service_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe Base::Service do
       allow(primary_service).to receive(:add_item) do
         persisted_service_item.instance_variable_set(:@primary_service_id, "primary-create-ivar-123")
         persisted_service_item.instance_variable_set(:@primary_service_url, "https://example.test/tasks/primary-create-ivar-123")
-        {id: "primary-create-ivar-123"}
+        { id: "primary-create-ivar-123" }
       end
 
       expect do

--- a/spec/models/base/service_spec.rb
+++ b/spec/models/base/service_spec.rb
@@ -118,6 +118,25 @@ RSpec.describe Base::Service do
       expect(service_item).to have_received(:find_matching_item_in).with([existing_item]).once
     end
 
+    it "does not load primary items when there are no service items to sync" do
+      allow(service).to receive(:items_to_sync).and_return([])
+
+      result = service.sync_to_primary(primary_service)
+
+      expect(result["items_synced"]).to eq(0)
+      expect(service).not_to have_received(:existing_items)
+    end
+
+    it "fails instead of pretending to sync when the primary service is unavailable" do
+      unavailable_primary = double("UnavailablePrimary", friendly_name: "Primary Service", authorized: false)
+
+      result = service.sync_to_primary(unavailable_primary)
+
+      expect(result["status"]).to eq("failed")
+      expect(result["error_message"]).to eq("Failed to sync with Primary Service: service is not authorized")
+      expect(service_item).not_to have_received(:find_matching_item_in)
+    end
+
     it "persists a sync collection for matched items that sync successfully" do
       persisted_service_item = sync_item_class.create!(
         title: "Persisted service task",
@@ -216,7 +235,7 @@ RSpec.describe Base::Service do
       allow(primary_service).to receive(:add_item) do
         persisted_service_item.instance_variable_set(:@primary_service_id, "primary-create-ivar-123")
         persisted_service_item.instance_variable_set(:@primary_service_url, "https://example.test/tasks/primary-create-ivar-123")
-        { id: "primary-create-ivar-123" }
+        {id: "primary-create-ivar-123"}
       end
 
       expect do
@@ -284,7 +303,38 @@ RSpec.describe Base::Service do
     end
   end
 
+  describe "#existing_items" do
+    it "uses metadata-only reads for primary items" do
+      allow(primary_service).to receive(:items_to_sync).and_return([existing_item])
+
+      expect(service.send(:existing_items, primary_service)).to eq([existing_item])
+      expect(primary_service).to have_received(:items_to_sync).with(
+        tags: ["Test Service"],
+        inbox: true,
+        only_modified_dates: true
+      )
+    end
+  end
+
+  describe "#existing_items_for" do
+    it "uses targeted primary lookups when the primary service supports them" do
+      allow(primary_service).to receive(:matching_items_for).with([service_item], tag: "Test Service").and_return([existing_item])
+
+      expect(service.existing_items_for(primary_service, [service_item])).to eq([existing_item])
+    end
+  end
+
   describe "#sync_from_primary" do
+    it "fails before reading primary items when the primary service is unavailable" do
+      unavailable_primary = double("UnavailablePrimary", friendly_name: "Primary Service", authorized: false)
+
+      result = service.sync_from_primary(unavailable_primary)
+
+      expect(result["status"]).to eq("failed")
+      expect(result["error_message"]).to eq("Failed to sync with Primary Service: service is not authorized")
+      expect(result["items_synced"]).to eq(0)
+    end
+
     it "persists a sync collection for newly created service items" do
       primary_item = primary_sync_item_class.create!(
         title: "Newly created service task",

--- a/spec/models/base/service_spec.rb
+++ b/spec/models/base/service_spec.rb
@@ -315,14 +315,13 @@ RSpec.describe Base::Service do
   end
 
   describe "#existing_items" do
-    it "uses metadata-only reads for primary items" do
+    it "uses full reads so generic sync ID matching can inspect provider metadata" do
       allow(primary_service).to receive(:items_to_sync).and_return([existing_item])
 
       expect(service.send(:existing_items, primary_service)).to eq([existing_item])
       expect(primary_service).to have_received(:items_to_sync).with(
         tags: ["Test Service"],
-        inbox: true,
-        only_modified_dates: true
+        inbox: true
       )
     end
   end

--- a/spec/models/base/service_spec.rb
+++ b/spec/models/base/service_spec.rb
@@ -137,6 +137,17 @@ RSpec.describe Base::Service do
       expect(service_item).not_to have_received(:find_matching_item_in)
     end
 
+    it "fails before returning success when the primary service is unavailable and no service items are present" do
+      unavailable_primary = double("UnavailablePrimary", friendly_name: "Primary Service", authorized: false)
+      allow(service).to receive(:items_to_sync).and_return([])
+
+      result = service.sync_to_primary(unavailable_primary)
+
+      expect(result["status"]).to eq("failed")
+      expect(result["error_message"]).to eq("Failed to sync with Primary Service: service is not authorized")
+      expect(service).not_to have_received(:items_to_sync)
+    end
+
     it "persists a sync collection for matched items that sync successfully" do
       persisted_service_item = sync_item_class.create!(
         title: "Persisted service task",

--- a/spec/models/omnifocus/service_unit_spec.rb
+++ b/spec/models/omnifocus/service_unit_spec.rb
@@ -328,6 +328,37 @@ RSpec.describe Omnifocus::Service, :full_options do
       expect(matches.first.github_id).to eq("gh-1")
     end
 
+    it "uses metadata-backed title matches when the stored OmniFocus sync ID is stale" do
+      service_item = OpenStruct.new(omnifocus_id: "stale-task", friendly_title: "Task 1")
+      tag_ref = double("TagRef", get: true)
+      tag_tasks = double(
+        "TagTasks",
+        id_: double(get: ["task-1"]),
+        name: double(get: ["Task 1"]),
+        completed: double(get: [false]),
+        modification_date: double(get: [Time.current])
+      )
+      inbox_tasks = double(
+        "InboxTasks",
+        id_: double(get: []),
+        name: double(get: []),
+        completed: double(get: []),
+        modification_date: double(get: [])
+      )
+      allow(flattened_tasks).to receive(:ID).with("stale-task").and_raise(StandardError)
+      allow(tag_ref).to receive(:tasks).and_return(tag_tasks)
+      flattened_tags = double("FlattenedTags")
+      allow(flattened_tags).to receive(:[]).with("Github").and_return(tag_ref)
+      allow(mock_omnifocus_app).to receive(:flattened_tags).and_return(flattened_tags)
+      allow(mock_omnifocus_app).to receive(:inbox_tasks).and_return(inbox_tasks)
+      Omnifocus::Task.create!(external_id: "task-1", title: "Task 1", notes: "github_id: gh-1")
+
+      matches = service.matching_items_for([service_item], tag: "Github")
+
+      expect(matches.map(&:external_id)).to eq(["task-1"])
+      expect(matches.first.github_id).to eq("gh-1")
+    end
+
     it "does not return title matches when sync metadata cannot be loaded" do
       service_item = OpenStruct.new(friendly_title: "Task 1")
       tag_ref = double("TagRef", get: true)
@@ -351,6 +382,64 @@ RSpec.describe Omnifocus::Service, :full_options do
       allow(mock_omnifocus_app).to receive(:flattened_tags).and_return(flattened_tags)
       allow(mock_omnifocus_app).to receive(:inbox_tasks).and_return(inbox_tasks)
       expect(flattened_tasks).not_to receive(:ID)
+
+      matches = service.matching_items_for([service_item], tag: "Github")
+
+      expect(matches).to eq([])
+    end
+
+    it "does not return title matches when cached notes are empty" do
+      service_item = OpenStruct.new(friendly_title: "Task 1")
+      tag_ref = double("TagRef", get: true)
+      tag_tasks = double(
+        "TagTasks",
+        id_: double(get: ["task-1"]),
+        name: double(get: ["Task 1"]),
+        completed: double(get: [false]),
+        modification_date: double(get: [Time.current])
+      )
+      inbox_tasks = double(
+        "InboxTasks",
+        id_: double(get: []),
+        name: double(get: []),
+        completed: double(get: []),
+        modification_date: double(get: [])
+      )
+      allow(tag_ref).to receive(:tasks).and_return(tag_tasks)
+      flattened_tags = double("FlattenedTags")
+      allow(flattened_tags).to receive(:[]).with("Github").and_return(tag_ref)
+      allow(mock_omnifocus_app).to receive(:flattened_tags).and_return(flattened_tags)
+      allow(mock_omnifocus_app).to receive(:inbox_tasks).and_return(inbox_tasks)
+      Omnifocus::Task.create!(external_id: "task-1", title: "Task 1", notes: "")
+
+      matches = service.matching_items_for([service_item], tag: "Github")
+
+      expect(matches).to eq([])
+    end
+
+    it "does not return title matches when cached notes lack metadata for the source provider" do
+      service_item = OpenStruct.new(friendly_title: "Task 1")
+      tag_ref = double("TagRef", get: true)
+      tag_tasks = double(
+        "TagTasks",
+        id_: double(get: ["task-1"]),
+        name: double(get: ["Task 1"]),
+        completed: double(get: [false]),
+        modification_date: double(get: [Time.current])
+      )
+      inbox_tasks = double(
+        "InboxTasks",
+        id_: double(get: []),
+        name: double(get: []),
+        completed: double(get: []),
+        modification_date: double(get: [])
+      )
+      allow(tag_ref).to receive(:tasks).and_return(tag_tasks)
+      flattened_tags = double("FlattenedTags")
+      allow(flattened_tags).to receive(:[]).with("Github").and_return(tag_ref)
+      allow(mock_omnifocus_app).to receive(:flattened_tags).and_return(flattened_tags)
+      allow(mock_omnifocus_app).to receive(:inbox_tasks).and_return(inbox_tasks)
+      Omnifocus::Task.create!(external_id: "task-1", title: "Task 1", notes: "asana_id: asana-1")
 
       matches = service.matching_items_for([service_item], tag: "Github")
 

--- a/spec/models/omnifocus/service_unit_spec.rb
+++ b/spec/models/omnifocus/service_unit_spec.rb
@@ -75,25 +75,25 @@ RSpec.describe Omnifocus::Service, :full_options do
     let(:service) { described_class.new(options:) }
     let(:mock_task1) do
       double("OmnifocusTask1",
-        id_: double(get: "task-1"),
-        name: double(get: "Task 1"),
-        completed: double(get: false),
-        note: double(get: ""),
-        containing_project: double(get: :missing_value),
-        tags: double(get: []),
-        tasks: double(get: []),
-        modification_date: double(get: Time.now))
+             id_: double(get: "task-1"),
+             name: double(get: "Task 1"),
+             completed: double(get: false),
+             note: double(get: ""),
+             containing_project: double(get: :missing_value),
+             tags: double(get: []),
+             tasks: double(get: []),
+             modification_date: double(get: Time.now))
     end
     let(:mock_task2) do
       double("OmnifocusTask2",
-        id_: double(get: "task-2"),
-        name: double(get: "Task 2"),
-        completed: double(get: false),
-        note: double(get: ""),
-        containing_project: double(get: :missing_value),
-        tags: double(get: []),
-        tasks: double(get: []),
-        modification_date: double(get: Time.now))
+             id_: double(get: "task-2"),
+             name: double(get: "Task 2"),
+             completed: double(get: false),
+             note: double(get: ""),
+             containing_project: double(get: :missing_value),
+             tags: double(get: []),
+             tasks: double(get: []),
+             modification_date: double(get: Time.now))
     end
 
     before do
@@ -174,25 +174,25 @@ RSpec.describe Omnifocus::Service, :full_options do
     context "with sub-items" do
       let(:mock_parent_task) do
         double("ParentTask",
-          id_: double(get: "parent-1"),
-          name: double(get: "Parent Task"),
-          completed: double(get: false),
-          note: double(get: ""),
-          containing_project: double(get: :missing_value),
-          tags: double(get: []),
-          tasks: double(get: [mock_subtask]),
-          modification_date: double(get: Time.now))
+               id_: double(get: "parent-1"),
+               name: double(get: "Parent Task"),
+               completed: double(get: false),
+               note: double(get: ""),
+               containing_project: double(get: :missing_value),
+               tags: double(get: []),
+               tasks: double(get: [mock_subtask]),
+               modification_date: double(get: Time.now))
       end
       let(:mock_subtask) do
         double("Subtask",
-          id_: double(get: "subtask-1"),
-          name: double(get: "Subtask"),
-          completed: double(get: false),
-          note: double(get: ""),
-          containing_project: double(get: :missing_value),
-          tags: double(get: []),
-          tasks: double(get: []),
-          modification_date: double(get: Time.now))
+               id_: double(get: "subtask-1"),
+               name: double(get: "Subtask"),
+               completed: double(get: false),
+               note: double(get: ""),
+               containing_project: double(get: :missing_value),
+               tags: double(get: []),
+               tasks: double(get: []),
+               modification_date: double(get: Time.now))
       end
 
       before do
@@ -295,6 +295,36 @@ RSpec.describe Omnifocus::Service, :full_options do
       matches = service.matching_items_for([service_item], tag: "Github")
 
       expect(matches.map(&:title)).to eq(["Task 1"])
+      expect(matches.first.github_id).to eq("gh-1")
+    end
+
+    it "uses persisted sync metadata for normalized title matches" do
+      service_item = OpenStruct.new(friendly_title: "Buy milk")
+      tag_ref = double("TagRef", get: true)
+      tag_tasks = double(
+        "TagTasks",
+        id_: double(get: ["task-1"]),
+        name: double(get: ["  BUY MILK  "]),
+        completed: double(get: [false]),
+        modification_date: double(get: [Time.current])
+      )
+      inbox_tasks = double(
+        "InboxTasks",
+        id_: double(get: []),
+        name: double(get: []),
+        completed: double(get: []),
+        modification_date: double(get: [])
+      )
+      allow(tag_ref).to receive(:tasks).and_return(tag_tasks)
+      flattened_tags = double("FlattenedTags")
+      allow(flattened_tags).to receive(:[]).with("Github").and_return(tag_ref)
+      allow(mock_omnifocus_app).to receive(:flattened_tags).and_return(flattened_tags)
+      allow(mock_omnifocus_app).to receive(:inbox_tasks).and_return(inbox_tasks)
+      Omnifocus::Task.create!(external_id: "task-1", title: "  BUY MILK  ", notes: "github_id: gh-1")
+
+      matches = service.matching_items_for([service_item], tag: "Github")
+
+      expect(matches.map(&:external_id)).to eq(["task-1"])
       expect(matches.first.github_id).to eq("gh-1")
     end
 

--- a/spec/models/omnifocus/service_unit_spec.rb
+++ b/spec/models/omnifocus/service_unit_spec.rb
@@ -75,25 +75,25 @@ RSpec.describe Omnifocus::Service, :full_options do
     let(:service) { described_class.new(options:) }
     let(:mock_task1) do
       double("OmnifocusTask1",
-             id_: double(get: "task-1"),
-             name: double(get: "Task 1"),
-             completed: double(get: false),
-             note: double(get: ""),
-             containing_project: double(get: :missing_value),
-             tags: double(get: []),
-             tasks: double(get: []),
-             modification_date: double(get: Time.now))
+        id_: double(get: "task-1"),
+        name: double(get: "Task 1"),
+        completed: double(get: false),
+        note: double(get: ""),
+        containing_project: double(get: :missing_value),
+        tags: double(get: []),
+        tasks: double(get: []),
+        modification_date: double(get: Time.now))
     end
     let(:mock_task2) do
       double("OmnifocusTask2",
-             id_: double(get: "task-2"),
-             name: double(get: "Task 2"),
-             completed: double(get: false),
-             note: double(get: ""),
-             containing_project: double(get: :missing_value),
-             tags: double(get: []),
-             tasks: double(get: []),
-             modification_date: double(get: Time.now))
+        id_: double(get: "task-2"),
+        name: double(get: "Task 2"),
+        completed: double(get: false),
+        note: double(get: ""),
+        containing_project: double(get: :missing_value),
+        tags: double(get: []),
+        tasks: double(get: []),
+        modification_date: double(get: Time.now))
     end
 
     before do
@@ -124,6 +124,36 @@ RSpec.describe Omnifocus::Service, :full_options do
       end
     end
 
+    context "with metadata-only reads" do
+      let(:metadata_properties) do
+        {
+          id_: "task-1",
+          name: "Task 1",
+          completed: false,
+          completion_date: nil,
+          modification_date: Time.current,
+          note: "github_id: gh-1"
+        }
+      end
+
+      before do
+        allow(mock_task1).to receive(:properties_).and_return(double(get: metadata_properties))
+      end
+
+      it "hydrates from task properties instead of per-attribute AppleScript reads" do
+        expect(mock_task1).not_to receive(:note)
+        expect(mock_task1).not_to receive(:tags)
+        expect(mock_task1).not_to receive(:tasks)
+
+        tasks = service.items_to_sync(tags: ["TaskBridge"], inbox: false, only_modified_dates: true)
+
+        expect(tasks.length).to eq(1)
+        expect(tasks.first.external_id).to eq("task-1")
+        expect(tasks.first.title).to eq("Task 1")
+        expect(tasks.first.github_id).to eq("gh-1")
+      end
+    end
+
     context "when a task reference goes stale while reading the id" do
       let(:stale_id) { double("StaleTaskId") }
       let(:stale_task) { double("StaleTask", id_: stale_id) }
@@ -144,25 +174,25 @@ RSpec.describe Omnifocus::Service, :full_options do
     context "with sub-items" do
       let(:mock_parent_task) do
         double("ParentTask",
-               id_: double(get: "parent-1"),
-               name: double(get: "Parent Task"),
-               completed: double(get: false),
-               note: double(get: ""),
-               containing_project: double(get: :missing_value),
-               tags: double(get: []),
-               tasks: double(get: [mock_subtask]),
-               modification_date: double(get: Time.now))
+          id_: double(get: "parent-1"),
+          name: double(get: "Parent Task"),
+          completed: double(get: false),
+          note: double(get: ""),
+          containing_project: double(get: :missing_value),
+          tags: double(get: []),
+          tasks: double(get: [mock_subtask]),
+          modification_date: double(get: Time.now))
       end
       let(:mock_subtask) do
         double("Subtask",
-               id_: double(get: "subtask-1"),
-               name: double(get: "Subtask"),
-               completed: double(get: false),
-               note: double(get: ""),
-               containing_project: double(get: :missing_value),
-               tags: double(get: []),
-               tasks: double(get: []),
-               modification_date: double(get: Time.now))
+          id_: double(get: "subtask-1"),
+          name: double(get: "Subtask"),
+          completed: double(get: false),
+          note: double(get: ""),
+          containing_project: double(get: :missing_value),
+          tags: double(get: []),
+          tasks: double(get: []),
+          modification_date: double(get: Time.now))
       end
 
       before do
@@ -205,6 +235,125 @@ RSpec.describe Omnifocus::Service, :full_options do
     it "returns empty array when no tags match" do
       tasks = service.tagged_tasks(["NonExistentTag"])
       expect(tasks).to eq([])
+    end
+  end
+
+  describe "#matching_items_for" do
+    let(:service) { described_class.new(options:) }
+    let(:properties) do
+      {
+        id_: "task-1",
+        name: "Task 1",
+        completed: false,
+        completion_date: nil,
+        modification_date: Time.current,
+        note: "github_id: gh-1"
+      }
+    end
+    let(:matching_task) { double("MatchingTask", properties_: double(get: properties)) }
+    let(:flattened_tasks) { double("FlattenedTasks") }
+
+    before do
+      allow(mock_omnifocus_app).to receive(:flattened_tasks).and_return(flattened_tasks)
+    end
+
+    it "finds candidates by stored OmniFocus sync ID" do
+      service_item = OpenStruct.new(omnifocus_id: "task-1", friendly_title: "Task 1")
+      task_ref = double("TaskRef", get: matching_task)
+      allow(flattened_tasks).to receive(:ID).with("task-1").and_return(task_ref)
+
+      matches = service.matching_items_for([service_item], tag: "Github")
+
+      expect(matches.map(&:external_id)).to eq(["task-1"])
+      expect(matches.first.github_id).to eq("gh-1")
+    end
+
+    it "uses persisted sync metadata for exact title matches" do
+      service_item = OpenStruct.new(friendly_title: "Task 1")
+      tag_ref = double("TagRef", get: true)
+      tag_tasks = double(
+        "TagTasks",
+        id_: double(get: ["task-1"]),
+        name: double(get: ["Task 1"]),
+        completed: double(get: [false]),
+        modification_date: double(get: [Time.current])
+      )
+      inbox_tasks = double(
+        "InboxTasks",
+        id_: double(get: []),
+        name: double(get: []),
+        completed: double(get: []),
+        modification_date: double(get: [])
+      )
+      allow(tag_ref).to receive(:tasks).and_return(tag_tasks)
+      flattened_tags = double("FlattenedTags")
+      allow(flattened_tags).to receive(:[]).with("Github").and_return(tag_ref)
+      allow(mock_omnifocus_app).to receive(:flattened_tags).and_return(flattened_tags)
+      allow(mock_omnifocus_app).to receive(:inbox_tasks).and_return(inbox_tasks)
+      Omnifocus::Task.create!(external_id: "task-1", title: "Task 1", notes: "github_id: gh-1")
+
+      matches = service.matching_items_for([service_item], tag: "Github")
+
+      expect(matches.map(&:title)).to eq(["Task 1"])
+      expect(matches.first.github_id).to eq("gh-1")
+    end
+
+    it "does not return title matches when sync metadata cannot be loaded" do
+      service_item = OpenStruct.new(friendly_title: "Task 1")
+      tag_ref = double("TagRef", get: true)
+      tag_tasks = double(
+        "TagTasks",
+        id_: double(get: ["task-1"]),
+        name: double(get: ["Task 1"]),
+        completed: double(get: [false]),
+        modification_date: double(get: [Time.current])
+      )
+      inbox_tasks = double(
+        "InboxTasks",
+        id_: double(get: []),
+        name: double(get: []),
+        completed: double(get: []),
+        modification_date: double(get: [])
+      )
+      allow(tag_ref).to receive(:tasks).and_return(tag_tasks)
+      flattened_tags = double("FlattenedTags")
+      allow(flattened_tags).to receive(:[]).with("Github").and_return(tag_ref)
+      allow(mock_omnifocus_app).to receive(:flattened_tags).and_return(flattened_tags)
+      allow(mock_omnifocus_app).to receive(:inbox_tasks).and_return(inbox_tasks)
+      expect(flattened_tasks).not_to receive(:ID)
+
+      matches = service.matching_items_for([service_item], tag: "Github")
+
+      expect(matches).to eq([])
+    end
+
+    it "includes inbox tasks in targeted title lookup" do
+      service_item = OpenStruct.new(friendly_title: "Inbox Task")
+      tag_ref = double("TagRef", get: true)
+      tag_tasks = double(
+        "TagTasks",
+        id_: double(get: []),
+        name: double(get: []),
+        completed: double(get: []),
+        modification_date: double(get: [])
+      )
+      inbox_tasks = double(
+        "InboxTasks",
+        id_: double(get: ["task-1"]),
+        name: double(get: ["Inbox Task"]),
+        completed: double(get: [false]),
+        modification_date: double(get: [Time.current])
+      )
+      allow(tag_ref).to receive(:tasks).and_return(tag_tasks)
+      flattened_tags = double("FlattenedTags")
+      allow(flattened_tags).to receive(:[]).with("Github").and_return(tag_ref)
+      allow(mock_omnifocus_app).to receive(:flattened_tags).and_return(flattened_tags)
+      allow(mock_omnifocus_app).to receive(:inbox_tasks).and_return(inbox_tasks)
+      Omnifocus::Task.create!(external_id: "task-1", title: "Inbox Task", notes: "github_id: gh-1")
+
+      matches = service.matching_items_for([service_item], tag: "Github")
+
+      expect(matches.map(&:external_id)).to eq(["task-1"])
     end
   end
 

--- a/spec/models/omnifocus/task_spec.rb
+++ b/spec/models/omnifocus/task_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Omnifocus::Task" do
       completed:,
       note: notes,
       containing_project:,
-      tags: tags.map { |tag| OpenStruct.new({ name: tag }) },
+      tags: tags.map { |tag| OpenStruct.new({name: tag}) },
       tasks:
     }.compact)
   end
@@ -83,7 +83,7 @@ RSpec.describe "Omnifocus::Task" do
       it "sets a due date in December" do
         parsed_date = Chronic.parse("12 - December")
         # If the date is in the past, the code adds 1 year
-        expected_date = parsed_date < Time.now ? parsed_date + 1.year : parsed_date
+        expected_date = (parsed_date < Time.now) ? parsed_date + 1.year : parsed_date
         expect(task.due_date).to eq(expected_date)
       end
 
@@ -111,7 +111,7 @@ RSpec.describe "Omnifocus::Task" do
 
     before do
       task_with_nil_tags.instance_variable_set(:@tags, nil)
-      allow(task_with_nil_tags).to receive(:options).and_return({ uses_personal_tags: true, personal_tags: ["Personal"] })
+      allow(task_with_nil_tags).to receive(:options).and_return({uses_personal_tags: true, personal_tags: ["Personal"]})
     end
 
     it "personal? returns false without raising" do
@@ -122,7 +122,7 @@ RSpec.describe "Omnifocus::Task" do
 
   context "when sub_items is nil" do
     let(:tasks) { nil }
-    let(:nil_sub_task) { Omnifocus::Task.new(omnifocus_task: OpenStruct.new({ id_: "sub_nil", name: "SubNil", completed: false, note: "", tasks: nil })) }
+    let(:nil_sub_task) { Omnifocus::Task.new(omnifocus_task: OpenStruct.new({id_: "sub_nil", name: "SubNil", completed: false, note: "", tasks: nil})) }
 
     it "sub_item_count defaults to 0 instead of nil" do
       nil_sub_task.read_original
@@ -154,6 +154,30 @@ RSpec.describe "Omnifocus::Task" do
     it "skips the stale sub_item" do
       expect(task.sub_items.map(&:external_id)).to eq(["sub_ok"])
       expect(task.sub_item_count).to eq(1)
+    end
+  end
+
+  context "with metadata-only reads" do
+    let(:metadata_task_data) do
+      double(
+        "OmnifocusMetadataTask",
+        id_: "metadata-task",
+        name: "Metadata task",
+        completed: false,
+        completion_date: nil,
+        modification_date: Time.current,
+        note: ""
+      )
+    end
+    let(:metadata_task) { Omnifocus::Task.new(omnifocus_task: metadata_task_data) }
+
+    it "does not read project, tags, due date, or sub-items" do
+      metadata_task.read_original(only_modified_dates: true)
+
+      expect(metadata_task.external_id).to eq("metadata-task")
+      expect(metadata_task.title).to eq("Metadata task")
+      expect(metadata_task.sub_items).to eq([])
+      expect(metadata_task.sub_item_count).to eq(0)
     end
   end
 end

--- a/spec/models/omnifocus/task_spec.rb
+++ b/spec/models/omnifocus/task_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Omnifocus::Task" do
       completed:,
       note: notes,
       containing_project:,
-      tags: tags.map { |tag| OpenStruct.new({name: tag}) },
+      tags: tags.map { |tag| OpenStruct.new({ name: tag }) },
       tasks:
     }.compact)
   end
@@ -83,7 +83,7 @@ RSpec.describe "Omnifocus::Task" do
       it "sets a due date in December" do
         parsed_date = Chronic.parse("12 - December")
         # If the date is in the past, the code adds 1 year
-        expected_date = (parsed_date < Time.now) ? parsed_date + 1.year : parsed_date
+        expected_date = parsed_date < Time.now ? parsed_date + 1.year : parsed_date
         expect(task.due_date).to eq(expected_date)
       end
 
@@ -111,7 +111,7 @@ RSpec.describe "Omnifocus::Task" do
 
     before do
       task_with_nil_tags.instance_variable_set(:@tags, nil)
-      allow(task_with_nil_tags).to receive(:options).and_return({uses_personal_tags: true, personal_tags: ["Personal"]})
+      allow(task_with_nil_tags).to receive(:options).and_return({ uses_personal_tags: true, personal_tags: ["Personal"] })
     end
 
     it "personal? returns false without raising" do
@@ -122,7 +122,7 @@ RSpec.describe "Omnifocus::Task" do
 
   context "when sub_items is nil" do
     let(:tasks) { nil }
-    let(:nil_sub_task) { Omnifocus::Task.new(omnifocus_task: OpenStruct.new({id_: "sub_nil", name: "SubNil", completed: false, note: "", tasks: nil})) }
+    let(:nil_sub_task) { Omnifocus::Task.new(omnifocus_task: OpenStruct.new({ id_: "sub_nil", name: "SubNil", completed: false, note: "", tasks: nil })) }
 
     it "sub_item_count defaults to 0 instead of nil" do
       nil_sub_task.read_original

--- a/spec/tasks/sync_task_spec.rb
+++ b/spec/tasks/sync_task_spec.rb
@@ -206,6 +206,68 @@ RSpec.describe "task_bridge:sync task" do
     )
   end
 
+  it "exits non-zero when a service returns a failed sync result" do
+    logger = instance_double(StructuredLogger, save_service_log!: nil)
+    stub_logger_summary(logger)
+    primary_service = instance_double("Primary::Service")
+    failing_service = instance_double(
+      "Failing::Service",
+      friendly_name: "Failing",
+      items_to_sync: [],
+      sync_strategies: [:from_primary]
+    )
+    passing_service = instance_double(
+      "Passing::Service",
+      friendly_name: "Passing",
+      items_to_sync: [],
+      sync_strategies: [:from_primary]
+    )
+
+    allow(failing_service).to receive(:should_sync?).and_return(true)
+    allow(passing_service).to receive(:should_sync?).and_return(true)
+    allow(failing_service).to receive(:sync_from_primary).with(primary_service, service_items: []).and_return(
+      {
+        service: "Failing",
+        status: "failed",
+        last_attempted: "2024-01-01T09:00:00.000000Z",
+        last_failed: "2024-01-01T09:00:00.000000Z",
+        items_synced: 0,
+        error_class: "ProviderError",
+        error_message: "provider unavailable"
+      }.stringify_keys
+    )
+    allow(passing_service).to receive(:sync_from_primary).with(primary_service, service_items: []).and_return(
+      {
+        service: "Passing",
+        last_attempted: "2024-01-01T09:00:00.000000Z",
+        last_successful: "2024-01-01T09:00:00.000000Z",
+        items_synced: 1
+      }.stringify_keys
+    )
+
+    stub_sync_defaults(services: %w[Failing Passing])
+    allow(Chamber).to receive(:dig!).with(:task_bridge, :all_supported_services).and_return(%w[Primary Failing Passing])
+    stub_service("Primary", primary_service)
+    stub_service("Failing", failing_service)
+    stub_service("Passing", passing_service)
+    allow(StructuredLogger).to receive(:new).and_return(logger)
+
+    capture_output do
+      expect { invoke_task }.to raise_error(SystemExit) { |error| expect(error.status).to eq(1) }
+    end
+
+    expect(passing_service).to have_received(:sync_from_primary).with(primary_service, service_items: [])
+    expect(logger).to have_received(:save_service_log!).with(
+      array_including(
+        hash_including(
+          "service" => "Failing",
+          "status" => "failed",
+          "error_message" => "provider unavailable"
+        )
+      )
+    )
+  end
+
   it "does not preload service items for delete runs" do
     logger = instance_double(StructuredLogger, save_service_log!: nil)
     stub_logger_summary(logger)


### PR DESCRIPTION
## Summary
- optimize OmniFocus primary lookups while avoiding unsafe title matches without sync metadata
- fail sync runs explicitly when the primary service is unavailable and propagate returned provider failures to the rake exit status
- add OmniFocus AppleScript preflight warming and coverage for metadata-only reads, inbox lookup, and failed-result exits

## Verification
- bundle exec rspec --tag '~no_ci'\n- bundle exec standardrb app/models/base/sync_item.rb app/models/omnifocus/task.rb app/services/base/service.rb app/services/omnifocus/service.rb lib/tasks/sync.rake spec/models/base/service_spec.rb spec/models/omnifocus/service_unit_spec.rb spec/models/omnifocus/task_spec.rb spec/tasks/sync_task_spec.rb\n- git diff --check\n- bundle exec rails runner 'service = Omnifocus::Service.new; puts "OmniFocus authorized=#{service.authorized}"'\n- bundle exec rake task_bridge:sync -- --pretend --force